### PR TITLE
feat: Add AppServiceProvider with DI bindings and Eloquent repositories

### DIFF
--- a/expense-management/backend/app/Infrastructure/Persistence/Eloquent/Repositories/EloquentApprovalFlowRepository.php
+++ b/expense-management/backend/app/Infrastructure/Persistence/Eloquent/Repositories/EloquentApprovalFlowRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Domain\Approval\Entities\ApprovalFlow;
+use App\Domain\Approval\Entities\ApprovalStep;
+use App\Domain\Approval\Repositories\ApprovalFlowRepositoryInterface;
+use App\Infrastructure\Persistence\Eloquent\Models\ApprovalFlowModel;
+use Illuminate\Support\Str;
+
+class EloquentApprovalFlowRepository implements ApprovalFlowRepositoryInterface
+{
+    public function findById(string $id, string $tenantId): ?ApprovalFlow
+    {
+        $model = ApprovalFlowModel::with('steps')
+            ->where('tenant_id', $tenantId)
+            ->find($id);
+
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    public function findDefault(string $tenantId): ?ApprovalFlow
+    {
+        $model = ApprovalFlowModel::with('steps')
+            ->where('tenant_id', $tenantId)
+            ->where('is_default', true)
+            ->where('is_active', true)
+            ->first();
+
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    public function findAllActive(string $tenantId): array
+    {
+        return ApprovalFlowModel::with('steps')
+            ->where('tenant_id', $tenantId)
+            ->where('is_active', true)
+            ->orderBy('is_default', 'desc')
+            ->orderBy('name')
+            ->get()
+            ->map(fn($m) => $this->toDomain($m))
+            ->toArray();
+    }
+
+    public function save(ApprovalFlow $flow): void
+    {
+        $model = ApprovalFlowModel::firstOrNew(['id' => $flow->getId()]);
+        $model->tenant_id   = $flow->getTenantId();
+        $model->name        = $flow->getName();
+        $model->description = $flow->getDescription();
+        $model->is_default  = $flow->isDefault();
+        $model->is_active   = $flow->isActive();
+        $model->conditions  = $flow->getConditions();
+        $model->save();
+    }
+
+    private function toDomain(ApprovalFlowModel $model): ApprovalFlow
+    {
+        $steps = $model->steps->map(fn($s) => new ApprovalStep(
+            id:           $s->id,
+            flowId:       $s->approval_flow_id,
+            stepNumber:   $s->step_number,
+            name:         $s->name,
+            approverType: $s->approver_type,
+            approverIds:  $s->approver_ids ?? [],
+            isRequired:   $s->is_required,
+        ))->toArray();
+
+        return new ApprovalFlow(
+            id:          $model->id,
+            tenantId:    $model->tenant_id,
+            name:        $model->name,
+            description: $model->description,
+            isDefault:   $model->is_default,
+            isActive:    $model->is_active,
+            conditions:  $model->conditions ?? [],
+            steps:       $steps,
+        );
+    }
+}

--- a/expense-management/backend/app/Infrastructure/Persistence/Eloquent/Repositories/EloquentUserRepository.php
+++ b/expense-management/backend/app/Infrastructure/Persistence/Eloquent/Repositories/EloquentUserRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Domain\User\Entities\User;
+use App\Domain\User\Repositories\UserRepositoryInterface;
+use App\Infrastructure\Persistence\Eloquent\Models\UserModel;
+
+class EloquentUserRepository implements UserRepositoryInterface
+{
+    public function findById(string $id, string $tenantId): ?User
+    {
+        $model = UserModel::where('tenant_id', $tenantId)->find($id);
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    public function findByEmail(string $email, string $tenantId): ?User
+    {
+        $model = UserModel::where('tenant_id', $tenantId)
+            ->where('email', $email)
+            ->first();
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    public function findAllActive(string $tenantId): array
+    {
+        return UserModel::where('tenant_id', $tenantId)
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get()
+            ->map(fn($m) => $this->toDomain($m))
+            ->toArray();
+    }
+
+    public function save(User $user): void
+    {
+        $model = UserModel::firstOrNew(['id' => $user->getId()]);
+        $model->tenant_id   = $user->getTenantId();
+        $model->role_id     = $user->getRoleId();
+        $model->name        = $user->getName();
+        $model->email       = $user->getEmail();
+        $model->department  = $user->getDepartment();
+        $model->is_active   = $user->isActive();
+        $model->save();
+    }
+
+    public function delete(string $id, string $tenantId): void
+    {
+        UserModel::where('tenant_id', $tenantId)->where('id', $id)->delete();
+    }
+
+    private function toDomain(UserModel $model): User
+    {
+        return new User(
+            id:         $model->id,
+            tenantId:   $model->tenant_id,
+            roleId:     $model->role_id,
+            name:       $model->name,
+            email:      $model->email,
+            department: $model->department,
+            isActive:   $model->is_active,
+        );
+    }
+}

--- a/expense-management/backend/app/Providers/AppServiceProvider.php
+++ b/expense-management/backend/app/Providers/AppServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\Approval\Repositories\ApprovalFlowRepositoryInterface;
+use App\Domain\Expense\Repositories\ExpenseRepositoryInterface;
+use App\Domain\User\Repositories\UserRepositoryInterface;
+use App\Infrastructure\Persistence\Eloquent\Repositories\EloquentApprovalFlowRepository;
+use App\Infrastructure\Persistence\Eloquent\Repositories\EloquentExpenseRepository;
+use App\Infrastructure\Persistence\Eloquent\Repositories\EloquentUserRepository;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(
+            ExpenseRepositoryInterface::class,
+            EloquentExpenseRepository::class,
+        );
+
+        $this->app->bind(
+            ApprovalFlowRepositoryInterface::class,
+            EloquentApprovalFlowRepository::class,
+        );
+
+        $this->app->bind(
+            UserRepositoryInterface::class,
+            EloquentUserRepository::class,
+        );
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Summary

- `AppServiceProvider`: Binds domain repository interfaces to Eloquent implementations via Laravel's IoC container
- `EloquentApprovalFlowRepository`: Implements `ApprovalFlowRepositoryInterface` — findById, findDefault, findAllActive, save with domain object mapping
- `EloquentUserRepository`: Implements `UserRepositoryInterface` — findById, findByEmail, findAllActive, save, delete

## Design

Uses the Repository pattern to decouple domain logic from persistence. All repositories accept `tenantId` parameters for multi-tenant isolation. Domain entities are reconstructed from Eloquent models in private `toDomain()` methods.

## Test plan

- [ ] Run `php artisan tinker` to verify bindings resolve correctly
- [ ] Verify `ApprovalFlowRepositoryInterface` resolves to `EloquentApprovalFlowRepository`
- [ ] Verify `UserRepositoryInterface` resolves to `EloquentUserRepository`
- [ ] Run existing PHPUnit tests — all should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_