### PR TITLE
feat: Add database seeders for permissions, roles, tenants, and categories

### DIFF
--- a/expense-management/backend/database/seeders/DatabaseSeeder.php
+++ b/expense-management/backend/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->call([
+            PermissionSeeder::class,
+            TenantSeeder::class,
+        ]);
+    }
+}

--- a/expense-management/backend/database/seeders/PermissionSeeder.php
+++ b/expense-management/backend/database/seeders/PermissionSeeder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PermissionSeeder extends Seeder
+{
+    private const PERMISSIONS = [
+        // Expense permissions
+        'expense.view.own'   => '自分の経費申請を閲覧',
+        'expense.view.all'   => '全経費申請を閲覧',
+        'expense.create'     => '経費申請を作成',
+        'expense.edit.own'   => '自分の経費申請を編集',
+        'expense.delete.own' => '自分の経費申請を削除',
+        'expense.submit'     => '経費申請を提出',
+        'expense.cancel'     => '経費申請をキャンセル',
+        'expense.approve'    => '経費申請を承認',
+        'expense.reject'     => '経費申請を却下',
+        'expense.export'     => '経費データをエクスポート',
+        // Category permissions
+        'category.view'      => 'カテゴリを閲覧',
+        'category.manage'    => 'カテゴリを管理',
+        // Approval flow permissions
+        'approval_flow.view'   => '承認フローを閲覧',
+        'approval_flow.manage' => '承認フローを管理',
+        // User permissions
+        'user.view'   => 'ユーザーを閲覧',
+        'user.manage' => 'ユーザーを管理',
+        // Report permissions
+        'report.view'   => 'レポートを閲覧',
+        'report.export' => 'レポートをエクスポート',
+    ];
+
+    private const ROLES = [
+        'admin' => [
+            'name'        => '管理者',
+            'permissions' => [
+                'expense.view.own', 'expense.view.all', 'expense.create',
+                'expense.edit.own', 'expense.delete.own', 'expense.submit',
+                'expense.cancel', 'expense.approve', 'expense.reject', 'expense.export',
+                'category.view', 'category.manage',
+                'approval_flow.view', 'approval_flow.manage',
+                'user.view', 'user.manage',
+                'report.view', 'report.export',
+            ],
+        ],
+        'approver' => [
+            'name'        => '承認者',
+            'permissions' => [
+                'expense.view.own', 'expense.view.all', 'expense.create',
+                'expense.edit.own', 'expense.submit', 'expense.cancel',
+                'expense.approve', 'expense.reject',
+                'category.view', 'approval_flow.view',
+                'user.view', 'report.view',
+            ],
+        ],
+        'employee' => [
+            'name'        => '一般社員',
+            'permissions' => [
+                'expense.view.own', 'expense.create', 'expense.edit.own',
+                'expense.delete.own', 'expense.submit', 'expense.cancel',
+                'category.view',
+            ],
+        ],
+    ];
+
+    public function run(): void
+    {
+        $now = now();
+        $permissionIds = [];
+
+        foreach (self::PERMISSIONS as $code => $description) {
+            $id = Str::uuid()->toString();
+            DB::table('permissions')->upsert(
+                ['id' => $id, 'code' => $code, 'description' => $description, 'created_at' => $now, 'updated_at' => $now],
+                ['code'],
+                ['description', 'updated_at']
+            );
+            $permissionIds[$code] = DB::table('permissions')->where('code', $code)->value('id');
+        }
+
+        foreach (self::ROLES as $slug => $roleData) {
+            $id = Str::uuid()->toString();
+            DB::table('roles')->upsert(
+                ['id' => $id, 'slug' => $slug, 'name' => $roleData['name'], 'created_at' => $now, 'updated_at' => $now],
+                ['slug'],
+                ['name', 'updated_at']
+            );
+            $roleId = DB::table('roles')->where('slug', $slug)->value('id');
+
+            DB::table('role_permissions')->where('role_id', $roleId)->delete();
+            foreach ($roleData['permissions'] as $permCode) {
+                if (isset($permissionIds[$permCode])) {
+                    DB::table('role_permissions')->insert([
+                        'role_id'       => $roleId,
+                        'permission_id' => $permissionIds[$permCode],
+                        'created_at'    => $now,
+                        'updated_at'    => $now,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/expense-management/backend/database/seeders/TenantSeeder.php
+++ b/expense-management/backend/database/seeders/TenantSeeder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class TenantSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $now = now();
+
+        $tenantId = Str::uuid()->toString();
+        DB::table('tenants')->upsert(
+            [
+                'id'         => $tenantId,
+                'name'       => 'デモ企業株式会社',
+                'slug'       => 'demo',
+                'plan'       => 'standard',
+                'is_active'  => true,
+                'settings'   => json_encode(['timezone' => 'Asia/Tokyo', 'currency' => 'JPY', 'fiscal_month_start' => 4]),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            ['slug'],
+            ['name', 'plan', 'is_active', 'settings', 'updated_at']
+        );
+        $tenantId = DB::table('tenants')->where('slug', 'demo')->value('id');
+
+        $adminRoleId    = DB::table('roles')->where('slug', 'admin')->value('id');
+        $approverRoleId = DB::table('roles')->where('slug', 'approver')->value('id');
+        $employeeRoleId = DB::table('roles')->where('slug', 'employee')->value('id');
+
+        $users = [
+            ['name' => '管理者 太郎', 'email' => 'admin@demo.example.com',    'role_id' => $adminRoleId,    'department' => '情報システム部'],
+            ['name' => '承認者 花子', 'email' => 'approver@demo.example.com', 'role_id' => $approverRoleId, 'department' => '経理部'],
+            ['name' => '社員 次郎',   'email' => 'employee@demo.example.com', 'role_id' => $employeeRoleId, 'department' => '営業部'],
+        ];
+
+        foreach ($users as $user) {
+            DB::table('users')->upsert(
+                [
+                    'id'         => Str::uuid()->toString(),
+                    'tenant_id'  => $tenantId,
+                    'role_id'    => $user['role_id'],
+                    'name'       => $user['name'],
+                    'email'      => $user['email'],
+                    'password'   => Hash::make('password'),
+                    'department' => $user['department'],
+                    'is_active'  => true,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ],
+                ['email', 'tenant_id'],
+                ['name', 'role_id', 'department', 'updated_at']
+            );
+        }
+
+        $categories = [
+            ['name' => '交通費',     'code' => 'TRANSPORT',   'description' => '電車・バス・タクシー等の交通費'],
+            ['name' => '宿泊費',     'code' => 'LODGING',     'description' => '出張時の宿泊費'],
+            ['name' => '飲食費',     'code' => 'MEAL',        'description' => '会議・接待等の飲食費'],
+            ['name' => '消耗品費',   'code' => 'SUPPLIES',    'description' => 'オフィス消耗品等'],
+            ['name' => '通信費',     'code' => 'TELECOM',     'description' => '電話・インターネット等の通信費'],
+            ['name' => '書籍・教材', 'code' => 'EDUCATION',   'description' => '業務に関する書籍・教材費'],
+            ['name' => 'その他',     'code' => 'OTHER',       'description' => '上記に該当しない経費'],
+        ];
+
+        foreach ($categories as $cat) {
+            DB::table('categories')->upsert(
+                [
+                    'id'          => Str::uuid()->toString(),
+                    'tenant_id'   => $tenantId,
+                    'name'        => $cat['name'],
+                    'code'        => $cat['code'],
+                    'description' => $cat['description'],
+                    'is_active'   => true,
+                    'sort_order'  => 0,
+                    'created_at'  => $now,
+                    'updated_at'  => $now,
+                ],
+                ['tenant_id', 'code'],
+                ['name', 'description', 'is_active', 'updated_at']
+            );
+        }
+
+        $approverUser = DB::table('users')
+            ->where('tenant_id', $tenantId)
+            ->where('email', 'approver@demo.example.com')
+            ->first();
+
+        $flowId = Str::uuid()->toString();
+        DB::table('approval_flows')->upsert(
+            [
+                'id'          => $flowId,
+                'tenant_id'   => $tenantId,
+                'name'        => '標準承認フロー',
+                'description' => 'すべての経費申請に適用されるデフォルト承認フロー',
+                'is_default'  => true,
+                'is_active'   => true,
+                'conditions'  => json_encode([]),
+                'created_at'  => $now,
+                'updated_at'  => $now,
+            ],
+            ['tenant_id', 'name'],
+            ['description', 'is_default', 'is_active', 'updated_at']
+        );
+        $flowId = DB::table('approval_flows')
+            ->where('tenant_id', $tenantId)
+            ->where('name', '標準承認フロー')
+            ->value('id');
+
+        DB::table('approval_steps')->upsert(
+            [
+                'id'               => Str::uuid()->toString(),
+                'approval_flow_id' => $flowId,
+                'step_number'      => 1,
+                'name'             => '経理部承認',
+                'approver_type'    => 'specific_user',
+                'approver_ids'     => json_encode($approverUser ? [$approverUser->id] : []),
+                'is_required'      => true,
+                'created_at'       => $now,
+                'updated_at'       => $now,
+            ],
+            ['approval_flow_id', 'step_number'],
+            ['name', 'approver_type', 'approver_ids', 'updated_at']
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `PermissionSeeder`: Seeds 18 permissions across expense/category/approval/user/report domains and assigns them to 3 roles (admin, approver, employee)
- `TenantSeeder`: Seeds a demo tenant with 3 users (admin, approver, employee), 7 expense categories, and a default single-step approval flow
- `DatabaseSeeder`: Orchestrates seeder execution order

## Demo credentials

| Role     | Email                       | Password   |
|----------|-----------------------------|------------|
| Admin    | admin@demo.example.com      | password   |
| Approver | approver@demo.example.com   | password   |
| Employee | employee@demo.example.com   | password   |
| Tenant slug | `demo` | — |

## Test plan

- [ ] `php artisan migrate:fresh --seed` completes without errors
- [ ] All 18 permissions exist in DB
- [ ] 3 roles with correct permission sets
- [ ] Demo users can log in via `/api/v1/auth/login`
- [ ] Re-running seeder is idempotent (uses `upsert`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_