### PR TITLE
feat: Add k6 load testing scenarios - smoke, load, stress, soak

### DIFF
--- a/expense-management/load-testing/README.md
+++ b/expense-management/load-testing/README.md
@@ -1,0 +1,33 @@
+# Load Testing with k6
+
+Scenarios:
+
+| File | VUs | Duration | Purpose |
+|------|-----|----------|---------|
+| `smoke.js`  | 1   | 1m   | Baseline sanity check |
+| `load.js`   | 50  | 17m  | Expected production load |
+| `stress.js` | 200 | 15m  | Find breaking point |
+| `soak.js`   | 30  | 4h   | Detect degradation over time |
+
+## Running
+
+```bash
+# Smoke
+BASE_URL=https://api.example.com k6 run load-testing/k6/smoke.js
+
+# Load
+BASE_URL=https://api.example.com k6 run load-testing/k6/load.js
+
+# Stress
+BASE_URL=https://api.example.com k6 run load-testing/k6/stress.js
+
+# Soak (long-running)
+BASE_URL=https://api.example.com k6 run load-testing/k6/soak.js
+```
+
+## SLO Targets
+
+- Error rate < 0.1%
+- p95 response time < 500ms
+- p99 response time < 1000ms
+- Availability > 99.9%

--- a/expense-management/load-testing/k6/auth.js
+++ b/expense-management/load-testing/k6/auth.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export function login(tenantSlug = 'demo', email = 'employee@demo.example.com', password = 'password') {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ tenant_slug: tenantSlug, email, password }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  check(res, { 'login 200': (r) => r.status === 200 });
+
+  return res.json('data.token');
+}
+
+export function authHeaders(token) {
+  return {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+}

--- a/expense-management/load-testing/k6/load.js
+++ b/expense-management/load-testing/k6/load.js
@@ -1,0 +1,76 @@
+/**
+ * Load test — expected production load.
+ * Ramps up to 50 VUs over 5 min, holds for 10 min, ramps down.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { login, authHeaders } from './auth.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+const expenseCreateDuration = new Trend('expense_create_duration');
+const expenseListDuration   = new Trend('expense_list_duration');
+const errorRate             = new Rate('errors');
+const expensesCreated       = new Counter('expenses_created');
+
+export const options = {
+  stages: [
+    { duration: '5m',  target: 50 },
+    { duration: '10m', target: 50 },
+    { duration: '2m',  target: 0  },
+  ],
+  thresholds: {
+    http_req_failed:        ['rate<0.001'],
+    http_req_duration:      ['p(95)<500', 'p(99)<1000'],
+    expense_create_duration: ['p(95)<800'],
+    expense_list_duration:   ['p(95)<300'],
+    errors:                  ['rate<0.01'],
+  },
+};
+
+export function setup() {
+  return { token: login() };
+}
+
+export default function ({ token }) {
+  const headers = authHeaders(token);
+
+  // 60% list, 20% detail, 20% create
+  const rand = Math.random();
+
+  if (rand < 0.6) {
+    const start = Date.now();
+    const res = http.get(`${BASE_URL}/api/v1/expenses?per_page=20`, { headers });
+    expenseListDuration.add(Date.now() - start);
+    const ok = check(res, { 'list 200': (r) => r.status === 200 });
+    if (!ok) errorRate.add(1);
+  } else if (rand < 0.8) {
+    const listRes = http.get(`${BASE_URL}/api/v1/expenses?per_page=5`, { headers });
+    const id = listRes.json('data.0.id');
+    if (id) {
+      const res = http.get(`${BASE_URL}/api/v1/expenses/${id}`, { headers });
+      const ok = check(res, { 'detail 200': (r) => r.status === 200 });
+      if (!ok) errorRate.add(1);
+    }
+  } else {
+    const catRes = http.get(`${BASE_URL}/api/v1/categories`, { headers });
+    const categoryId = catRes.json('data.0.id');
+    const start = Date.now();
+    const res = http.post(
+      `${BASE_URL}/api/v1/expenses`,
+      JSON.stringify({
+        title: `Load Test ${Date.now()}`,
+        currency: 'JPY',
+        items: [{ category_id: categoryId, description: '負荷テスト', amount: 5000, quantity: 1, expense_date: new Date().toISOString().split('T')[0] }],
+      }),
+      { headers },
+    );
+    expenseCreateDuration.add(Date.now() - start);
+    const ok = check(res, { 'create 201': (r) => r.status === 201 });
+    if (ok) expensesCreated.add(1);
+    else errorRate.add(1);
+  }
+
+  sleep(1 + Math.random() * 2);
+}

--- a/expense-management/load-testing/k6/smoke.js
+++ b/expense-management/load-testing/k6/smoke.js
@@ -1,0 +1,52 @@
+/**
+ * Smoke test — minimal load to verify the system is functional.
+ * 1 VU, 1 minute. All checks must pass.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { login, authHeaders } from './auth.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export const options = {
+  vus: 1,
+  duration: '1m',
+  thresholds: {
+    http_req_failed:   ['rate<0.01'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+export default function () {
+  const token = login();
+  const headers = authHeaders(token);
+
+  // List expenses
+  const listRes = http.get(`${BASE_URL}/api/v1/expenses`, { headers });
+  check(listRes, { 'list 200': (r) => r.status === 200 });
+
+  // Get categories
+  const catRes = http.get(`${BASE_URL}/api/v1/categories`, { headers });
+  check(catRes, { 'categories 200': (r) => r.status === 200 });
+
+  // Create expense
+  const categoryId = catRes.json('data.0.id');
+  const createRes = http.post(
+    `${BASE_URL}/api/v1/expenses`,
+    JSON.stringify({
+      title: `Smoke Test Expense ${Date.now()}`,
+      currency: 'JPY',
+      items: [{
+        category_id:  categoryId,
+        description:  'スモークテスト明細',
+        amount:       1000,
+        quantity:     1,
+        expense_date: new Date().toISOString().split('T')[0],
+      }],
+    }),
+    { headers },
+  );
+  check(createRes, { 'create 201': (r) => r.status === 201 });
+
+  sleep(1);
+}

--- a/expense-management/load-testing/k6/soak.js
+++ b/expense-management/load-testing/k6/soak.js
@@ -1,0 +1,39 @@
+/**
+ * Soak test — steady load over a long duration to detect memory leaks / degradation.
+ * 30 VUs for 4 hours.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { login, authHeaders } from './auth.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const listDuration = new Trend('list_duration');
+
+export const options = {
+  stages: [
+    { duration: '5m',   target: 30  },
+    { duration: '230m', target: 30  },
+    { duration: '5m',   target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.001'],
+    http_req_duration: ['p(95)<600'],
+    list_duration:     ['p(95)<400'],
+  },
+};
+
+export function setup() {
+  return { token: login() };
+}
+
+export default function ({ token }) {
+  const headers = authHeaders(token);
+
+  const start = Date.now();
+  const res = http.get(`${BASE_URL}/api/v1/expenses?per_page=20`, { headers });
+  listDuration.add(Date.now() - start);
+  check(res, { 'list 200': (r) => r.status === 200 });
+
+  sleep(2 + Math.random());
+}

--- a/expense-management/load-testing/k6/stress.js
+++ b/expense-management/load-testing/k6/stress.js
@@ -1,0 +1,39 @@
+/**
+ * Stress test — push beyond expected capacity to find the breaking point.
+ * Ramps aggressively to 200 VUs.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+import { login, authHeaders } from './auth.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const errorRate = new Rate('errors');
+
+export const options = {
+  stages: [
+    { duration: '2m',  target: 50  },
+    { duration: '3m',  target: 100 },
+    { duration: '3m',  target: 150 },
+    { duration: '2m',  target: 200 },
+    { duration: '3m',  target: 200 },
+    { duration: '2m',  target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<2000'],
+    errors:            ['rate<0.1'],
+  },
+};
+
+export function setup() {
+  return { token: login() };
+}
+
+export default function ({ token }) {
+  const headers = authHeaders(token);
+  const res = http.get(`${BASE_URL}/api/v1/expenses?per_page=20`, { headers });
+  const ok = check(res, { '200 or 429': (r) => r.status === 200 || r.status === 429 });
+  if (!ok) errorRate.add(1);
+  sleep(0.5);
+}


### PR DESCRIPTION
## Summary

- `auth.js`: 共通ログインヘルパー（Bearer token取得）
- `smoke.js`: 1 VU × 1分、最小限の動作確認
- `load.js`: 最大50 VU × 17分、本番想定負荷。カスタムメトリクス（expense_create_duration, expense_list_duration）付き
- `stress.js`: 最大200 VU × 15分、限界点の特定
- `soak.js`: 30 VU × 4時間、メモリリーク・性能劣化の検出

## SLO閾値

| メトリクス | 目標値 |
|---|---|
| エラー率 | < 0.1% |
| p95レスポンスタイム | < 500ms |
| p99レスポンスタイム | < 1000ms |

## 実行方法

```bash
BASE_URL=https://api.example.com k6 run load-testing/k6/smoke.js
BASE_URL=https://api.example.com k6 run load-testing/k6/load.js
```

## Test plan

- [ ] `k6 run smoke.js` が全チェック合格
- [ ] `k6 run load.js` で p95 < 500ms を確認
- [ ] カスタムメトリクスがサマリーに表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_