### PR TITLE
test: Add Vitest unit tests for auth store, hooks, and expense types

### DIFF
--- a/expense-management/frontend/src/test/hooks/useExpenses.test.tsx
+++ b/expense-management/frontend/src/test/hooks/useExpenses.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useExpenses } from '../../hooks/useExpenses';
+
+const mockExpenseData = {
+  data: [
+    {
+      id: 'expense-1',
+      expense_number: 'EXP-2401-000001',
+      title: 'テスト経費',
+      status: 'draft',
+      status_label: '下書き',
+      total_amount: 5000,
+      total_amount_formatted: '¥5,000',
+      currency: 'JPY',
+      applicant: { id: 'user-1', name: 'テスト太郎', department: '営業部' },
+      items: [],
+      receipts: [],
+      approval_records: [],
+      can_edit: true,
+      can_submit: true,
+      can_cancel: false,
+      applied_at: null,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  ],
+  meta: { current_page: 1, last_page: 1, per_page: 20, total: 1 },
+};
+
+vi.mock('../../lib/api', () => ({
+  expenseApi: {
+    list:  vi.fn().mockResolvedValue(mockExpenseData),
+    get:   vi.fn().mockResolvedValue(mockExpenseData.data[0]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    submit: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+    cancel: vi.fn(),
+    exportCsv: vi.fn(),
+  },
+  categoryApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useExpenses', () => {
+  it('経費一覧を取得できる', async () => {
+    const { result } = renderHook(
+      () => useExpenses({ page: 1, per_page: 20 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.data).toHaveLength(1);
+    expect(result.current.data?.data[0].title).toBe('テスト経費');
+    expect(result.current.data?.meta.total).toBe(1);
+  });
+
+  it('ローディング状態を正しく返す', () => {
+    const { result } = renderHook(
+      () => useExpenses({ page: 1, per_page: 20 }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/expense-management/frontend/src/test/setup.ts
+++ b/expense-management/frontend/src/test/setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Suppress console.error for expected errors in tests
+vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/expense-management/frontend/src/test/stores/authStore.test.ts
+++ b/expense-management/frontend/src/test/stores/authStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAuthStore } from '../../stores/authStore';
+
+describe('authStore', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ token: null, user: null });
+  });
+
+  it('初期状態はtoken/userがnull', () => {
+    const { result } = renderHook(() => useAuthStore());
+    expect(result.current.token).toBeNull();
+    expect(result.current.user).toBeNull();
+  });
+
+  it('setAuthでtokenとuserを設定できる', () => {
+    const { result } = renderHook(() => useAuthStore());
+    const mockUser = { id: '1', name: 'テスト太郎', email: 'test@example.com', role: 'employee', permissions: [] };
+
+    act(() => {
+      result.current.setAuth('test-token', mockUser);
+    });
+
+    expect(result.current.token).toBe('test-token');
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it('logoutでtokenとuserがクリアされる', () => {
+    const { result } = renderHook(() => useAuthStore());
+    const mockUser = { id: '1', name: 'テスト太郎', email: 'test@example.com', role: 'employee', permissions: [] };
+
+    act(() => {
+      result.current.setAuth('test-token', mockUser);
+    });
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(result.current.token).toBeNull();
+    expect(result.current.user).toBeNull();
+  });
+
+  it('hasPermissionで権限チェックができる', () => {
+    const { result } = renderHook(() => useAuthStore());
+    const mockUser = {
+      id: '1', name: 'Test', email: 'test@example.com', role: 'approver',
+      permissions: ['expense.view.all', 'expense.approve'],
+    };
+
+    act(() => {
+      result.current.setAuth('token', mockUser);
+    });
+
+    expect(result.current.hasPermission('expense.approve')).toBe(true);
+    expect(result.current.hasPermission('expense.view.all')).toBe(true);
+    expect(result.current.hasPermission('user.manage')).toBe(false);
+  });
+
+  it('未ログイン時はhasPermissionがfalseを返す', () => {
+    const { result } = renderHook(() => useAuthStore());
+    expect(result.current.hasPermission('expense.view.all')).toBe(false);
+  });
+});

--- a/expense-management/frontend/src/test/types/expense.test.ts
+++ b/expense-management/frontend/src/test/types/expense.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { STATUS_LABELS, STATUS_COLORS } from '../../types/expense';
+import type { ExpenseStatus } from '../../types/expense';
+
+describe('expense types', () => {
+  const expectedStatuses: ExpenseStatus[] = [
+    'draft', 'submitted', 'partially_approved', 'approved', 'rejected', 'cancelled', 'paid',
+  ];
+
+  it('STATUS_LABELSが全ステータスを網羅している', () => {
+    expectedStatuses.forEach((status) => {
+      expect(STATUS_LABELS[status]).toBeDefined();
+      expect(typeof STATUS_LABELS[status]).toBe('string');
+    });
+  });
+
+  it('STATUS_COLORSが全ステータスを網羅している', () => {
+    expectedStatuses.forEach((status) => {
+      expect(STATUS_COLORS[status]).toBeDefined();
+      expect(STATUS_COLORS[status]).toContain('bg-');
+    });
+  });
+
+  it('STATUS_LABELSが日本語ラベルを返す', () => {
+    expect(STATUS_LABELS['draft']).toBe('下書き');
+    expect(STATUS_LABELS['submitted']).toBe('申請中');
+    expect(STATUS_LABELS['approved']).toBe('承認済み');
+    expect(STATUS_LABELS['rejected']).toBe('却下');
+    expect(STATUS_LABELS['paid']).toBe('支払済み');
+  });
+});


### PR DESCRIPTION
## Summary

- `src/test/setup.ts`: Vitest セットアップ（@testing-library/jest-dom インポート）
- `authStore.test.ts`: Zustand ストアのユニットテスト（5テスト）
  - 初期状態、setAuth、logout、hasPermission（権限あり/なし）
- `useExpenses.test.tsx`: TanStack Query フックのテスト（2テスト）
  - API モック、データ取得成功、ローディング状態
- `expense.test.ts`: 型・定数のテスト（3テスト）
  - STATUS_LABELS / STATUS_COLORS が全ステータスを網羅していることを検証

## カバレッジ対象

| ファイル | テスト数 |
|---------|---------|
| stores/authStore.ts | 5 |
| hooks/useExpenses.ts | 2 |
| types/expense.ts | 3 |

## Test plan

- [ ] `npm test` で全10テストが合格
- [ ] `npm run test:coverage` でカバレッジレポートが生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_