### PR TITLE
feat: Add Terraform IAM roles for ECS task/execution and outputs

### DIFF
--- a/expense-management/terraform/iam.tf
+++ b/expense-management/terraform/iam.tf
@@ -1,0 +1,134 @@
+# -------------------------------------------------------
+# ECS タスク実行ロール (ECR pull, CloudWatch Logs, SSM)
+# -------------------------------------------------------
+data "aws_iam_policy_document" "ecs_task_execution_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = "${local.prefix}-ecs-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_managed" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_task_execution_extra" {
+  name = "${local.prefix}-ecs-execution-extra"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter",
+          "secretsmanager:GetSecretValue",
+          "kms:Decrypt",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# -------------------------------------------------------
+# ECS タスクロール (S3, SES, SQS, Textract)
+# -------------------------------------------------------
+resource "aws_iam_role" "ecs_task" {
+  name               = "${local.prefix}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy" "ecs_task_s3" {
+  name = "${local.prefix}-ecs-task-s3"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+        ]
+        Resource = "arn:aws:s3:::${local.prefix}-receipts/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = "arn:aws:s3:::${local.prefix}-receipts"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_task_textract" {
+  name = "${local.prefix}-ecs-task-textract"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["textract:DetectDocumentText", "textract:AnalyzeDocument"]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_task_ses" {
+  name = "${local.prefix}-ecs-task-ses"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ses:SendEmail", "ses:SendRawEmail"]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# -------------------------------------------------------
+# Auto Scaling ロール
+# -------------------------------------------------------
+resource "aws_iam_role" "ecs_autoscaling" {
+  name = "${local.prefix}-ecs-autoscaling"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "application-autoscaling.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_autoscaling" {
+  role       = aws_iam_role.ecs_autoscaling.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+}

--- a/expense-management/terraform/locals.tf
+++ b/expense-management/terraform/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}

--- a/expense-management/terraform/outputs.tf
+++ b/expense-management/terraform/outputs.tf
@@ -1,0 +1,67 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "alb_dns_name" {
+  description = "ALB の DNS 名"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB の Route53 Zone ID"
+  value       = aws_lb.main.zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS クラスター名"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS サービス名"
+  value       = aws_ecs_service.app.name
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "ECS タスク実行ロール ARN"
+  value       = aws_iam_role.ecs_task_execution.arn
+}
+
+output "ecs_task_role_arn" {
+  description = "ECS タスクロール ARN"
+  value       = aws_iam_role.ecs_task.arn
+}
+
+output "rds_endpoint" {
+  description = "Aurora クラスターエンドポイント"
+  value       = aws_rds_cluster.main.endpoint
+  sensitive   = true
+}
+
+output "rds_reader_endpoint" {
+  description = "Aurora リーダーエンドポイント"
+  value       = aws_rds_cluster.main.reader_endpoint
+  sensitive   = true
+}
+
+output "elasticache_endpoint" {
+  description = "ElastiCache Redis エンドポイント"
+  value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+  sensitive   = true
+}
+
+output "s3_receipt_bucket" {
+  description = "領収書 S3 バケット名"
+  value       = aws_s3_bucket.receipts.bucket
+}
+
+output "cloudwatch_log_group" {
+  description = "CloudWatch ロググループ名"
+  value       = "/ecs/${local.prefix}"
+}
+
+output "sns_alarm_topic_arn" {
+  description = "アラート SNS トピック ARN"
+  value       = aws_sns_topic.alarms.arn
+}


### PR DESCRIPTION
## Summary

### `iam.tf`
- **ECS Task Execution Role**: ECR pull, CloudWatch Logs 書き込み、SSM Parameter Store / Secrets Manager からの機密情報取得
- **ECS Task Role**: S3（領収書バケット）読み書き、AWS Textract（OCR）、SES（メール送信）
- **Auto Scaling Role**: ECS Auto Scaling に必要な IAM ロール

### `outputs.tf`
全主要リソースの参照値をエクスポート:
- ALB DNS名・Zone ID
- ECS クラスター/サービス名
- IAM ロール ARN（execution/task）
- RDS エンドポイント（センシティブ）
- ElastiCache エンドポイント（センシティブ）
- S3 バケット名、CloudWatch ロググループ名、SNS トピック ARN

### `locals.tf`
`${project}-${environment}` プレフィックスとタグを一元管理

## セキュリティ

- 最小権限原則: S3 権限はレシートバケット (`/receipts/*`) のみ
- Textract は全リソースへのアクセスが必要（AWS 制約）
- 機密 output (`rds_endpoint` など) は `sensitive = true` で保護

## Test plan

- [ ] `terraform plan` がエラーなく完了
- [ ] `terraform apply` 後に `terraform output` で全 output が表示される
- [ ] ECS タスクが S3 へのアップロードに成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_