### PR TITLE
feat: Add Admin UserController and CategoryController

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/Admin/CategoryController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/Admin/CategoryController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Persistence\Eloquent\Models\CategoryModel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class CategoryController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $tenantId   = $request->attributes->get('tenant_id');
+        $categories = CategoryModel::where('tenant_id', $tenantId)
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get()
+            ->map(fn($c) => $this->format($c));
+
+        return response()->json(['data' => $categories]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $tenantId  = $request->attributes->get('tenant_id');
+        $validated = $request->validate([
+            'name'        => ['required', 'string', 'max:100'],
+            'code'        => ['required', 'string', 'max:50', 'alpha_num'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'parent_id'   => ['nullable', 'uuid', 'exists:categories,id'],
+            'sort_order'  => ['integer', 'min:0'],
+        ]);
+
+        $category = CategoryModel::create([
+            'id'          => Str::uuid()->toString(),
+            'tenant_id'   => $tenantId,
+            'name'        => $validated['name'],
+            'code'        => strtoupper($validated['code']),
+            'description' => $validated['description'] ?? null,
+            'parent_id'   => $validated['parent_id'] ?? null,
+            'sort_order'  => $validated['sort_order'] ?? 0,
+            'is_active'   => true,
+        ]);
+
+        return response()->json(['data' => $this->format($category)], 201);
+    }
+
+    public function update(Request $request, string $id): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $category = CategoryModel::where('tenant_id', $tenantId)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'        => ['sometimes', 'string', 'max:100'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'sort_order'  => ['integer', 'min:0'],
+            'is_active'   => ['boolean'],
+        ]);
+
+        $category->update($validated);
+
+        return response()->json(['data' => $this->format($category)]);
+    }
+
+    private function format(CategoryModel $c): array
+    {
+        return [
+            'id'          => $c->id,
+            'name'        => $c->name,
+            'code'        => $c->code,
+            'description' => $c->description,
+            'parent_id'   => $c->parent_id,
+            'sort_order'  => $c->sort_order,
+            'is_active'   => $c->is_active,
+        ];
+    }
+}

--- a/expense-management/backend/app/Http/Controllers/Api/V1/Admin/UserController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/Admin/UserController.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Domain\User\Repositories\UserRepositoryInterface;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Persistence\Eloquent\Models\RoleModel;
+use App\Infrastructure\Persistence\Eloquent\Models\UserModel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class UserController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+
+        $users = UserModel::with('role')
+            ->where('tenant_id', $tenantId)
+            ->orderBy('name')
+            ->paginate((int) $request->query('per_page', 20));
+
+        return response()->json([
+            'data' => $users->items(),
+            'meta' => [
+                'current_page' => $users->currentPage(),
+                'last_page'    => $users->lastPage(),
+                'per_page'     => $users->perPage(),
+                'total'        => $users->total(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $user     = UserModel::with('role')->where('tenant_id', $tenantId)->findOrFail($id);
+
+        return response()->json(['data' => $this->formatUser($user)]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+
+        $validated = $request->validate([
+            'name'       => ['required', 'string', 'max:100'],
+            'email'      => ['required', 'email', 'max:255'],
+            'password'   => ['required', 'string', 'min:8'],
+            'role_id'    => ['required', 'uuid', 'exists:roles,id'],
+            'department' => ['nullable', 'string', 'max:100'],
+        ]);
+
+        $exists = UserModel::where('tenant_id', $tenantId)
+            ->where('email', $validated['email'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json(['message' => 'このメールアドレスはすでに登録されています'], 422);
+        }
+
+        $user = UserModel::create([
+            'id'         => Str::uuid()->toString(),
+            'tenant_id'  => $tenantId,
+            'role_id'    => $validated['role_id'],
+            'name'       => $validated['name'],
+            'email'      => $validated['email'],
+            'password'   => Hash::make($validated['password']),
+            'department' => $validated['department'] ?? null,
+            'is_active'  => true,
+        ]);
+
+        $user->load('role');
+
+        return response()->json(['data' => $this->formatUser($user)], 201);
+    }
+
+    public function update(Request $request, string $id): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $user     = UserModel::where('tenant_id', $tenantId)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'       => ['sometimes', 'string', 'max:100'],
+            'role_id'    => ['sometimes', 'uuid', 'exists:roles,id'],
+            'department' => ['nullable', 'string', 'max:100'],
+            'is_active'  => ['boolean'],
+            'password'   => ['nullable', 'string', 'min:8'],
+        ]);
+
+        if (isset($validated['password'])) {
+            $validated['password'] = Hash::make($validated['password']);
+        } else {
+            unset($validated['password']);
+        }
+
+        $user->update($validated);
+        $user->load('role');
+
+        return response()->json(['data' => $this->formatUser($user)]);
+    }
+
+    public function destroy(Request $request, string $id): JsonResponse
+    {
+        $tenantId  = $request->attributes->get('tenant_id');
+        $currentId = $request->user()->id;
+
+        if ($id === $currentId) {
+            return response()->json(['message' => '自分自身は削除できません'], 422);
+        }
+
+        $user = UserModel::where('tenant_id', $tenantId)->findOrFail($id);
+        $user->update(['is_active' => false]);
+
+        return response()->json(null, 204);
+    }
+
+    private function formatUser(UserModel $model): array
+    {
+        return [
+            'id'          => $model->id,
+            'name'        => $model->name,
+            'email'       => $model->email,
+            'department'  => $model->department,
+            'is_active'   => $model->is_active,
+            'role'        => [
+                'id'   => $model->role->id,
+                'slug' => $model->role->slug,
+                'name' => $model->role->name,
+            ],
+            'last_login_at' => $model->last_login_at?->toIso8601String(),
+            'created_at'    => $model->created_at->toIso8601String(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- `Admin/UserController.php`: テナント内ユーザー管理（管理者専用）
  - ページネーション付き一覧、詳細、作成、更新、論理削除
  - 自分自身の削除を拒否（422）
  - パスワード更新はオプション（指定時のみ Hash::make）
  - 削除は物理削除せず `is_active=false` に変更
- `Admin/CategoryController.php`: 経費カテゴリ管理
  - 階層構造サポート（`parent_id`）
  - `code` は自動的に大文字に正規化
  - `sort_order` による表示順制御

## セキュリティ

- 全エンドポイントが `permission:user.manage` / `permission:category.manage` ミドルウェアで保護予定
- テナント ID スコープで他テナントのユーザーへアクセス不可

## APIエンドポイント

```
GET    /api/v1/admin/users
GET    /api/v1/admin/users/{id}
POST   /api/v1/admin/users
PATCH  /api/v1/admin/users/{id}
DELETE /api/v1/admin/users/{id}

GET    /api/v1/admin/categories
POST   /api/v1/admin/categories
PATCH  /api/v1/admin/categories/{id}
```

## Test plan

- [ ] 自分自身の削除で 422 エラー
- [ ] 別テナントのユーザーへのアクセスで 404
- [ ] パスワードなし更新でパスワードが変更されない
- [ ] カテゴリコードが大文字に正規化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_