### PR TITLE
feat: Add notification system - events, listeners, and controller

### DIFF
--- a/expense-management/backend/app/Events/ExpenseApproved.php
+++ b/expense-management/backend/app/Events/ExpenseApproved.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ExpenseApproved
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public readonly ExpenseModel $expense,
+        public readonly bool $isFullyApproved,
+    ) {}
+}

--- a/expense-management/backend/app/Events/ExpenseRejected.php
+++ b/expense-management/backend/app/Events/ExpenseRejected.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ExpenseRejected
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public readonly ExpenseModel $expense,
+        public readonly string $reason,
+    ) {}
+}

--- a/expense-management/backend/app/Events/ExpenseSubmitted.php
+++ b/expense-management/backend/app/Events/ExpenseSubmitted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ExpenseSubmitted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public readonly ExpenseModel $expense,
+    ) {}
+}

--- a/expense-management/backend/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/NotificationController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Persistence\Eloquent\Models\NotificationModel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $notifications = NotificationModel::where('user_id', $userId)
+            ->orderBy('created_at', 'desc')
+            ->paginate((int) $request->query('per_page', 20));
+
+        return response()->json([
+            'data' => $notifications->items(),
+            'meta' => [
+                'current_page' => $notifications->currentPage(),
+                'last_page'    => $notifications->lastPage(),
+                'per_page'     => $notifications->perPage(),
+                'total'        => $notifications->total(),
+                'unread_count' => NotificationModel::where('user_id', $userId)
+                    ->whereNull('read_at')
+                    ->count(),
+            ],
+        ]);
+    }
+
+    public function markAsRead(Request $request, string $id): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        NotificationModel::where('user_id', $userId)
+            ->where('id', $id)
+            ->update(['read_at' => now()]);
+
+        return response()->json(null, 204);
+    }
+
+    public function markAllAsRead(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        NotificationModel::where('user_id', $userId)
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return response()->json(null, 204);
+    }
+}

--- a/expense-management/backend/app/Listeners/SendExpenseStatusChangedNotification.php
+++ b/expense-management/backend/app/Listeners/SendExpenseStatusChangedNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\ExpenseApproved;
+use App\Events\ExpenseRejected;
+use App\Infrastructure\Persistence\Eloquent\Models\NotificationModel;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Str;
+
+class SendExpenseStatusChangedNotification implements ShouldQueue
+{
+    public string $queue = 'notifications';
+
+    public function handleApproved(ExpenseApproved $event): void
+    {
+        $expense = $event->expense;
+        $title   = $event->isFullyApproved ? '経費申請が承認されました' : '承認ステップを通過しました';
+        $body    = $event->isFullyApproved
+            ? "「{$expense->title}」が全ての承認ステップを通過しました。"
+            : "「{$expense->title}」の承認ステップが完了しました。";
+
+        $this->notify($expense->applicant_id, 'expense_approved', $title, $body, $expense->id);
+    }
+
+    public function handleRejected(ExpenseRejected $event): void
+    {
+        $expense = $event->expense;
+        $this->notify(
+            $expense->applicant_id,
+            'expense_rejected',
+            '経費申請が却下されました',
+            "「{$expense->title}」が却下されました。理由: {$event->reason}",
+            $expense->id,
+        );
+    }
+
+    private function notify(string $userId, string $type, string $title, string $body, string $expenseId): void
+    {
+        NotificationModel::create([
+            'id'      => Str::uuid()->toString(),
+            'user_id' => $userId,
+            'type'    => $type,
+            'title'   => $title,
+            'body'    => $body,
+            'data'    => json_encode(['expense_id' => $expenseId]),
+            'read_at' => null,
+        ]);
+    }
+}

--- a/expense-management/backend/app/Listeners/SendExpenseSubmittedNotification.php
+++ b/expense-management/backend/app/Listeners/SendExpenseSubmittedNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\ExpenseSubmitted;
+use App\Infrastructure\Persistence\Eloquent\Models\ApprovalFlowModel;
+use App\Infrastructure\Persistence\Eloquent\Models\NotificationModel;
+use App\Infrastructure\Persistence\Eloquent\Models\UserModel;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Str;
+
+class SendExpenseSubmittedNotification implements ShouldQueue
+{
+    public string $queue = 'notifications';
+
+    public function handle(ExpenseSubmitted $event): void
+    {
+        $expense  = $event->expense;
+        $tenantId = $expense->tenant_id;
+
+        $flow = ApprovalFlowModel::with('steps')
+            ->where('tenant_id', $tenantId)
+            ->where('is_default', true)
+            ->first();
+
+        if (!$flow || $flow->steps->isEmpty()) {
+            return;
+        }
+
+        $firstStep   = $flow->steps->sortBy('step_number')->first();
+        $approverIds = $firstStep->approver_ids ?? [];
+
+        foreach ($approverIds as $approverId) {
+            $approver = UserModel::find($approverId);
+            if (!$approver || !$approver->is_active) {
+                continue;
+            }
+
+            NotificationModel::create([
+                'id'        => Str::uuid()->toString(),
+                'user_id'   => $approverId,
+                'type'      => 'expense_submitted',
+                'title'     => '経費申請の承認依頼',
+                'body'      => "「{$expense->title}」の承認をお願いします。",
+                'data'      => json_encode(['expense_id' => $expense->id]),
+                'read_at'   => null,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

### Eloquent Events
- `ExpenseSubmitted`: 経費申請が提出されたときに発火
- `ExpenseApproved`: 承認ステップ完了・最終承認時に発火（`isFullyApproved` フラグ付き）
- `ExpenseRejected`: 却下時に発火（却下理由付き）

### Queue Listeners (非同期)
- `SendExpenseSubmittedNotification`: 承認依頼通知を次ステップの承認者全員に送信
- `SendExpenseStatusChangedNotification`: 申請者への承認/却下通知

### NotificationController
- `GET /api/v1/notifications`: 未読件数付きページネーション一覧
- `PATCH /api/v1/notifications/{id}/read`: 個別既読
- `POST /api/v1/notifications/read-all`: 全既読

## アーキテクチャ

```
ExpenseController::approve()
  → event(new ExpenseApproved($expense, $isFullyApproved))
    → SendExpenseStatusChangedNotification (Queue: notifications)
      → NotificationModel::create()
```

## Test plan

- [ ] 経費提出後に承認者の通知一覧に通知が追加される
- [ ] 承認後に申請者に通知が届く
- [ ] 却下後に申請者に却下理由付き通知が届く
- [ ] `markAllAsRead` で未読件数が 0 になる
- [ ] キューワーカー (`queue:work --queue=notifications`) で非同期処理される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_