### PR TITLE
feat: Add permission middleware, security headers, and exception handler

### DIFF
--- a/app/Providers/RateLimitServiceProvider.php
+++ b/app/Providers/RateLimitServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+
+class RateLimitServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Per-user API rate limit: 120 requests/minute
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(120)->by(
+                $request->user()?->id ?: $request->ip()
+            )->response(function () {
+                return response()->json([
+                    'message' => 'Too many requests. Please retry after a moment.',
+                    'code'    => 'RATE_LIMIT_EXCEEDED',
+                ], 429);
+            });
+        });
+
+        // Per-tenant rate limit: 1000 requests/minute across all users
+        RateLimiter::for('api.tenant', function (Request $request) {
+            $tenantId = $request->user()?->tenant_id ?? 'anonymous';
+            return Limit::perMinute(1000)->by("tenant:{$tenantId}")->response(function () {
+                return response()->json([
+                    'message' => 'Tenant API rate limit exceeded.',
+                    'code'    => 'TENANT_RATE_LIMIT_EXCEEDED',
+                ], 429);
+            });
+        });
+
+        // Strict limit for auth endpoints: 10 attempts/minute per IP
+        RateLimiter::for('auth', function (Request $request) {
+            return [
+                Limit::perMinute(10)->by($request->ip()),
+                Limit::perHour(50)->by($request->ip()),
+            ];
+        });
+
+        // Export endpoints: 5 per hour per user (expensive operations)
+        RateLimiter::for('exports', function (Request $request) {
+            return Limit::perHour(5)->by(
+                $request->user()?->id ?: $request->ip()
+            )->response(function () {
+                return response()->json([
+                    'message' => 'Export limit reached. You may generate up to 5 exports per hour.',
+                    'code'    => 'EXPORT_RATE_LIMIT_EXCEEDED',
+                ], 429);
+            });
+        });
+
+        // Webhook signature failures: block IP after 20 bad sigs in 5 minutes
+        RateLimiter::for('webhook.invalid', function (Request $request) {
+            return Limit::perMinutes(5, 20)->by($request->ip());
+        });
+    }
+}

--- a/expense-management/backend/app/Exceptions/Handler.php
+++ b/expense-management/backend/app/Exceptions/Handler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $dontFlash = ['current_password', 'password', 'password_confirmation'];
+
+    public function render($request, Throwable $e): JsonResponse
+    {
+        if ($e instanceof ValidationException) {
+            return response()->json([
+                'message' => '入力内容を確認してください',
+                'errors'  => $e->errors(),
+            ], 422);
+        }
+
+        if ($e instanceof ModelNotFoundException) {
+            return response()->json(['message' => '指定されたリソースが見つかりません'], 404);
+        }
+
+        if ($e instanceof AuthenticationException) {
+            return response()->json(['message' => '認証が必要です'], 401);
+        }
+
+        if ($e instanceof HttpException) {
+            return response()->json(
+                ['message' => $e->getMessage() ?: 'エラーが発生しました'],
+                $e->getStatusCode()
+            );
+        }
+
+        $status = 500;
+        $message = config('app.debug') ? $e->getMessage() : 'サーバーエラーが発生しました';
+
+        return response()->json(['message' => $message], $status);
+    }
+}

--- a/expense-management/backend/app/Http/Middleware/CheckPermission.php
+++ b/expense-management/backend/app/Http/Middleware/CheckPermission.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckPermission
+{
+    public function handle(Request $request, Closure $next, string ...$permissions): Response
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['message' => '認証が必要です'], 401);
+        }
+
+        $userPermissions = $user->role?->permissions?->pluck('code')->toArray() ?? [];
+
+        foreach ($permissions as $permission) {
+            if (!in_array($permission, $userPermissions, true)) {
+                return response()->json(
+                    ['message' => 'この操作を行う権限がありません'],
+                    403
+                );
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/expense-management/backend/app/Http/Middleware/ForceJsonResponse.php
+++ b/expense-management/backend/app/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ForceJsonResponse
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $request->headers->set('Accept', 'application/json');
+        return $next($request);
+    }
+}

--- a/expense-management/backend/app/Http/Middleware/SecurityHeaders.php
+++ b/expense-management/backend/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    private const HEADERS = [
+        'X-Content-Type-Options'           => 'nosniff',
+        'X-Frame-Options'                  => 'DENY',
+        'X-XSS-Protection'                 => '1; mode=block',
+        'Referrer-Policy'                  => 'strict-origin-when-cross-origin',
+        'Permissions-Policy'               => 'camera=(), microphone=(), geolocation=()',
+        'Strict-Transport-Security'        => 'max-age=31536000; includeSubDomains',
+        'Content-Security-Policy'          => "default-src 'none'; frame-ancestors 'none'",
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        foreach (self::HEADERS as $header => $value) {
+            $response->headers->set($header, $value);
+        }
+
+        // Remove server-identifying headers
+        $response->headers->remove('X-Powered-By');
+        $response->headers->remove('Server');
+
+        return $response;
+    }
+}

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RateLimiter::clear('auth');
+    }
+
+    public function test_auth_endpoint_rate_limited_after_threshold(): void
+    {
+        // Exhaust the auth rate limit
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson('/api/auth/login', [
+                'email'    => 'nonexistent@example.com',
+                'password' => 'wrong',
+            ]);
+        }
+
+        $this->postJson('/api/auth/login', [
+            'email'    => 'nonexistent@example.com',
+            'password' => 'wrong',
+        ])->assertStatus(429);
+    }
+
+    public function test_api_returns_rate_limit_headers(): void
+    {
+        $user = User::factory()->create(['tenant_id' => 1]);
+
+        $response = $this->actingAs($user)->getJson('/api/expenses');
+
+        $response->assertHeader('X-RateLimit-Limit');
+        $response->assertHeader('X-RateLimit-Remaining');
+    }
+
+    public function test_export_rate_limited_per_user(): void
+    {
+        $user = User::factory()->create(['tenant_id' => 1]);
+        RateLimiter::clear("exports:{$user->id}");
+
+        // Exhaust export limit
+        for ($i = 0; $i < 5; $i++) {
+            $this->actingAs($user)->postJson('/api/exports/expenses');
+        }
+
+        $this->actingAs($user)
+            ->postJson('/api/exports/expenses')
+            ->assertStatus(429)
+            ->assertJsonPath('code', 'EXPORT_RATE_LIMIT_EXCEEDED');
+    }
+}


### PR DESCRIPTION
## Summary

- `CheckPermission.php`: ミドルウェア — ユーザーのロールパーミッションを検証
  - `route()->middleware('permission:expense.approve')` の形式で使用
  - 複数パーミッションの AND 条件指定対応
- `ForceJsonResponse.php`: 全 API リクエストに `Accept: application/json` を強制（HTML エラーページの排除）
- `SecurityHeaders.php`: セキュリティヘッダーを全レスポンスに付与
  - `X-Content-Type-Options`, `X-Frame-Options`, `HSTS`, `CSP`, `Referrer-Policy`
  - `X-Powered-By` / `Server` ヘッダーを削除してフィンガープリントを隠蔽
- `Handler.php`: JSON 統一エラーレスポンス
  - ValidationException → 422 (errors マップ付き)
  - ModelNotFoundException → 404
  - AuthenticationException → 401
  - HttpException → ステータスコードそのまま
  - その他 → 500（本番は汎用メッセージ、debug モード時のみ詳細）

## Test plan

- [ ] 権限なしユーザーが `expense.approve` ルートにアクセスすると 403
- [ ] バリデーションエラーが `{"message":"...","errors":{...}}` 形式で返る
- [ ] `curl -I https://api.example.com/health` にセキュリティヘッダーが含まれる
- [ ] `X-Powered-By` ヘッダーが存在しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_