### PR TITLE
feat: Add ReportController with monthly, category, and approval analytics

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/ReportController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/ReportController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseItemModel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ReportController extends Controller
+{
+    /**
+     * 月次サマリー（月ごとの合計金額・件数・ステータス内訳）
+     */
+    public function monthly(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $year     = (int) $request->query('year',  now()->year);
+        $months   = collect(range(1, 12))->map(function (int $month) use ($tenantId, $year) {
+            $data = ExpenseModel::where('tenant_id', $tenantId)
+                ->whereYear('created_at', $year)
+                ->whereMonth('created_at', $month)
+                ->selectRaw('status, COUNT(*) as count, SUM(total_amount) as total')
+                ->groupBy('status')
+                ->get()
+                ->keyBy('status');
+
+            return [
+                'month'             => $month,
+                'year'              => $year,
+                'total_amount'      => $data->sum('total'),
+                'total_count'       => $data->sum('count'),
+                'by_status'         => $data->map(fn($r) => [
+                    'count'  => $r->count,
+                    'amount' => $r->total,
+                ]),
+            ];
+        });
+
+        return response()->json(['data' => $months, 'year' => $year]);
+    }
+
+    /**
+     * カテゴリ別集計
+     */
+    public function byCategory(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $from     = $request->query('from', now()->startOfMonth()->toDateString());
+        $to       = $request->query('to',   now()->toDateString());
+
+        $rows = ExpenseItemModel::join('expenses', 'expense_items.expense_id', '=', 'expenses.id')
+            ->join('categories', 'expense_items.category_id', '=', 'categories.id')
+            ->where('expenses.tenant_id', $tenantId)
+            ->whereIn('expenses.status', ['approved', 'paid'])
+            ->whereBetween('expense_items.expense_date', [$from, $to])
+            ->selectRaw('
+                categories.id,
+                categories.name,
+                categories.code,
+                COUNT(DISTINCT expenses.id)    AS expense_count,
+                SUM(expense_items.amount * expense_items.quantity) AS total_amount
+            ')
+            ->groupBy('categories.id', 'categories.name', 'categories.code')
+            ->orderByDesc('total_amount')
+            ->get();
+
+        return response()->json([
+            'data'  => $rows,
+            'from'  => $from,
+            'to'    => $to,
+            'total' => $rows->sum('total_amount'),
+        ]);
+    }
+
+    /**
+     * 申請者別集計
+     */
+    public function byApplicant(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $from     = $request->query('from', now()->startOfMonth()->toDateString());
+        $to       = $request->query('to',   now()->toDateString());
+
+        $rows = ExpenseModel::join('users', 'expenses.applicant_id', '=', 'users.id')
+            ->where('expenses.tenant_id', $tenantId)
+            ->whereIn('expenses.status', ['approved', 'paid'])
+            ->whereBetween(DB::raw('DATE(expenses.created_at)'), [$from, $to])
+            ->selectRaw('
+                users.id,
+                users.name,
+                users.department,
+                COUNT(*)            AS expense_count,
+                SUM(total_amount)   AS total_amount
+            ')
+            ->groupBy('users.id', 'users.name', 'users.department')
+            ->orderByDesc('total_amount')
+            ->limit(50)
+            ->get();
+
+        return response()->json([
+            'data'  => $rows,
+            'from'  => $from,
+            'to'    => $to,
+        ]);
+    }
+
+    /**
+     * 承認所要時間の統計
+     */
+    public function approvalStats(Request $request): JsonResponse
+    {
+        $tenantId = $request->attributes->get('tenant_id');
+        $from     = $request->query('from', now()->subMonths(3)->toDateString());
+        $to       = $request->query('to',   now()->toDateString());
+
+        $stats = ExpenseModel::where('tenant_id', $tenantId)
+            ->where('status', 'approved')
+            ->whereNotNull('applied_at')
+            ->whereBetween(DB::raw('DATE(approved_at)'), [$from, $to])
+            ->selectRaw('
+                AVG(TIMESTAMPDIFF(HOUR, applied_at, approved_at))   AS avg_hours,
+                MIN(TIMESTAMPDIFF(HOUR, applied_at, approved_at))   AS min_hours,
+                MAX(TIMESTAMPDIFF(HOUR, applied_at, approved_at))   AS max_hours,
+                COUNT(*)                                             AS approved_count
+            ')
+            ->first();
+
+        return response()->json([
+            'data' => [
+                'avg_hours'      => round($stats->avg_hours ?? 0, 1),
+                'min_hours'      => $stats->min_hours ?? 0,
+                'max_hours'      => $stats->max_hours ?? 0,
+                'approved_count' => $stats->approved_count ?? 0,
+            ],
+            'from' => $from,
+            'to'   => $to,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- `ReportController.php`: 4つのレポートエンドポイント

| エンドポイント | 説明 |
|---|---|
| `GET /api/v1/reports/monthly?year=2024` | 月次サマリー（ステータス内訳付き） |
| `GET /api/v1/reports/by-category?from=&to=` | カテゴリ別集計（承認済み・支払済みのみ） |
| `GET /api/v1/reports/by-applicant?from=&to=` | 申請者別集計（上位50名） |
| `GET /api/v1/reports/approval-stats?from=&to=` | 承認所要時間統計（avg/min/max） |

## クエリ最適化

- カテゴリ別: `FULLTEXT` の代わりに JOIN + GROUP BY で集計
- 申請者別: 上位50名に LIMIT してネットワーク転送量を削減
- 承認統計: `TIMESTAMPDIFF(HOUR, applied_at, approved_at)` で MySQL 側で計算

## 権限制御

- `report.view` パーミッション保持者のみアクセス可能
- 全エンドポイントでテナント ID によるスコープを適用

## Test plan

- [ ] 月次レポートが 12ヶ月分のデータを返す
- [ ] カテゴリ別が `total_amount` 降順でソートされる
- [ ] 別テナントのデータが混入しない
- [ ] `report.view` 権限なしで 403 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_