### PR TITLE
feat: Add NotificationBell component with real-time badge and dropdown

### DIFF
--- a/expense-management/frontend/src/components/layout/NotificationBell.tsx
+++ b/expense-management/frontend/src/components/layout/NotificationBell.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  read_at: string | null;
+  created_at: string;
+}
+
+interface NotificationMeta {
+  total: number;
+  unread_count: number;
+  current_page: number;
+  last_page: number;
+  per_page: number;
+}
+
+async function fetchNotifications(): Promise<{ data: Notification[]; meta: NotificationMeta }> {
+  const res = await fetch('/api/v1/notifications?per_page=10', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+  });
+  if (!res.ok) throw new Error('Failed to fetch notifications');
+  return res.json();
+}
+
+async function markAsRead(id: string): Promise<void> {
+  await fetch(`/api/v1/notifications/${id}/read`, {
+    method: 'PATCH',
+    headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+  });
+}
+
+async function markAllAsRead(): Promise<void> {
+  await fetch('/api/v1/notifications/read-all', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+  });
+}
+
+export function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: fetchNotifications,
+    refetchInterval: 60_000,
+  });
+
+  const markOneMutation = useMutation({
+    mutationFn: markAsRead,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+  });
+
+  const markAllMutation = useMutation({
+    mutationFn: markAllAsRead,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+  });
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const unread = data?.meta.unread_count ?? 0;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full"
+        aria-label="通知"
+      >
+        <BellIcon />
+        {unread > 0 && (
+          <span className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 rounded-lg border border-gray-200 bg-white shadow-lg z-50">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+            <span className="text-sm font-semibold text-gray-900">通知</span>
+            {unread > 0 && (
+              <button
+                onClick={() => markAllMutation.mutate()}
+                className="text-xs text-blue-600 hover:text-blue-800"
+              >
+                すべて既読
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto divide-y divide-gray-100">
+            {data?.data.length === 0 && (
+              <p className="px-4 py-8 text-center text-sm text-gray-500">通知はありません</p>
+            )}
+            {data?.data.map((n) => (
+              <button
+                key={n.id}
+                onClick={() => {
+                  if (!n.read_at) markOneMutation.mutate(n.id);
+                }}
+                className={`w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors ${
+                  n.read_at ? 'opacity-60' : ''
+                }`}
+              >
+                <div className="flex items-start gap-2">
+                  {!n.read_at && (
+                    <span className="mt-1.5 flex-shrink-0 w-2 h-2 rounded-full bg-blue-500" />
+                  )}
+                  <div className={!n.read_at ? '' : 'pl-4'}>
+                    <p className="text-sm font-medium text-gray-900">{n.title}</p>
+                    <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{n.body}</p>
+                    <p className="text-xs text-gray-400 mt-1">
+                      {new Date(n.created_at).toLocaleString('ja-JP')}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+    </svg>
+  );
+}

--- a/expense-management/frontend/src/hooks/useNotifications.ts
+++ b/expense-management/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,47 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+const notificationKeys = {
+  all:  () => ['notifications'] as const,
+  list: () => ['notifications', 'list'] as const,
+};
+
+const BASE = '/api/v1/notifications';
+
+async function apiFetch(path: string, options?: RequestInit) {
+  const token = localStorage.getItem('token');
+  const res = await fetch(path, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+  if (!res.ok && res.status !== 204) throw new Error(await res.text());
+  return res.status === 204 ? null : res.json();
+}
+
+export function useNotifications() {
+  return useQuery({
+    queryKey: notificationKeys.list(),
+    queryFn:  () => apiFetch(BASE + '?per_page=20'),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+}
+
+export function useMarkAsRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiFetch(`${BASE}/${id}/read`, { method: 'PATCH' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: notificationKeys.all() }),
+  });
+}
+
+export function useMarkAllAsRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiFetch(`${BASE}/read-all`, { method: 'POST' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: notificationKeys.all() }),
+  });
+}


### PR DESCRIPTION
## Summary

- `NotificationBell.tsx`: ヘッダー組み込みの通知ベルコンポーネント
  - 未読数バッジ（赤丸、9+ 表示）
  - ドロップダウンリスト（最新10件、未読は青ドット付き）
  - 個別既読・全既読ボタン
  - 60秒ごとに自動ポーリング
  - 外部クリックでドロップダウンを閉じる
- `useNotifications.ts`: TanStack Query フック
  - `useNotifications()`: ページネーション付き一覧
  - `useMarkAsRead()`: 個別既読
  - `useMarkAllAsRead()`: 全既読
  - staleTime: 30秒、refetchInterval: 60秒

## UX

- 未読通知クリックで即座に既読に変更（楽観的更新ではなく即時 mutation）
- 読み込み済み通知は opacity-60 で視覚的に区別
- アクセシビリティ: `aria-label="通知"` 付きボタン

## Test plan

- [ ] 未読件数バッジが正しく表示される
- [ ] 9件超の場合「9+」と表示される
- [ ] 通知をクリックすると既読になりバッジが減る
- [ ] 「すべて既読」でバッジが消える
- [ ] 外部クリックでドロップダウンが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_