### PR TITLE
feat: Add security scanning CI workflows - Trivy, CodeQL, composer/npm audit

### DIFF
--- a/expense-management/.github/workflows/dependency-review.yml
+++ b/expense-management/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main, claude/expense-management-system-FfaVv]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/expense-management/.github/workflows/security.yml
+++ b/expense-management/.github/workflows/security.yml
@@ -1,0 +1,157 @@
+name: Security Scanning
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 毎日 JST 11:00
+  push:
+    branches: [main, claude/expense-management-system-FfaVv]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  # -------------------------------------------------------
+  # Trivy: コンテナイメージ脆弱性スキャン
+  # -------------------------------------------------------
+  trivy-image:
+    name: Trivy Image Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f expense-management/docker/Dockerfile.php \
+            -t expense-management:${{ github.sha }} \
+            expense-management
+
+      - name: Run Trivy (image)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: expense-management:${{ github.sha }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+  # -------------------------------------------------------
+  # Trivy: ファイルシステム（依存関係）スキャン
+  # -------------------------------------------------------
+  trivy-fs:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy (filesystem)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: expense-management/backend
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  # -------------------------------------------------------
+  # CodeQL: PHP ソースコード静的解析
+  # -------------------------------------------------------
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [php, javascript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: codeql-${{ matrix.language }}
+
+  # -------------------------------------------------------
+  # PHP セキュリティ監査 (composer audit)
+  # -------------------------------------------------------
+  composer-audit:
+    name: Composer Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Run composer audit
+        working-directory: expense-management/backend
+        run: composer audit --no-dev --format=json > composer-audit.json || true
+
+      - name: Print audit summary
+        working-directory: expense-management/backend
+        run: |
+          if [ -s composer-audit.json ]; then
+            cat composer-audit.json | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+advisories = data.get('advisories', {})
+if advisories:
+    print(f'Found {len(advisories)} vulnerabilities:')
+    for pkg, info in advisories.items():
+        for adv in info:
+            print(f'  [{adv.get(\"severity\", \"unknown\").upper()}] {pkg}: {adv.get(\"title\", \"\")}')
+    sys.exit(1)
+else:
+    print('No vulnerabilities found')
+"
+          fi
+
+  # -------------------------------------------------------
+  # npm audit: フロントエンド依存関係
+  # -------------------------------------------------------
+  npm-audit:
+    name: npm Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: expense-management/frontend/package.json
+
+      - name: Install dependencies
+        working-directory: expense-management/frontend
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: expense-management/frontend
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

### `security.yml` — 5ジョブ構成
| ジョブ | ツール | 対象 | トリガー |
|---|---|---|---|
| `trivy-image` | Trivy | Dockerイメージ | push/PR/毎日 |
| `trivy-fs` | Trivy | backend ディレクトリ | push/PR/毎日 |
| `codeql` | CodeQL | PHP + JavaScript | push/PR/毎日 |
| `composer-audit` | composer audit | PHP 依存関係 | push/PR/毎日 |
| `npm-audit` | npm audit | frontend 依存関係 | push/PR/毎日 |

### `dependency-review.yml`
- PR 時に新規追加された依存パッケージの既知脆弱性を自動チェック
- HIGH 以上の脆弱性でブロック、PR コメントにサマリー投稿

## 設定詳細

- Trivy: `CRITICAL,HIGH` のみ、`ignore-unfixed: true`（修正なし脆弱性は無視）
- CodeQL: `security-extended` クエリセット（OWASP Top10 カバー）
- SARIF 形式で GitHub Security タブに統合
- スケジュール: 毎日 JST 11:00 (UTC 02:00)

## Test plan

- [ ] PRを作成すると全5ジョブが実行される
- [ ] CRITICAL な脆弱性があるとジョブが失敗する
- [ ] SARIF ファイルが GitHub Security タブに表示される
- [ ] `dependency-review` が新しい脆弱パッケージ追加でブロックする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_