### PR TITLE
feat: Add approval email job and monthly report generation job

### DIFF
--- a/expense-management/backend/app/Jobs/GenerateMonthlyReport.php
+++ b/expense-management/backend/app/Jobs/GenerateMonthlyReport.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use App\Infrastructure\Persistence\Eloquent\Models\TenantModel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class GenerateMonthlyReport implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int    $tries   = 1;
+    public int    $timeout = 300;
+    public string $queue   = 'reports';
+
+    public function __construct(
+        private readonly string $tenantId,
+        private readonly int    $year,
+        private readonly int    $month,
+    ) {}
+
+    public function handle(): void
+    {
+        $tenant = TenantModel::findOrFail($this->tenantId);
+
+        $expenses = ExpenseModel::where('tenant_id', $this->tenantId)
+            ->whereYear('created_at', $this->year)
+            ->whereMonth('created_at', $this->month)
+            ->with(['applicant', 'items.category'])
+            ->orderBy('created_at')
+            ->get();
+
+        $csv = $this->generateCsv($expenses);
+
+        $path = "reports/{$this->tenantId}/{$this->year}-{$this->month:02d}.csv";
+        Storage::disk('s3')->put($path, $csv, 'private');
+
+        // レポート生成完了をキャッシュに記録
+        Cache::put(
+            "report:monthly:{$this->tenantId}:{$this->year}:{$this->month}",
+            ['path' => $path, 'generated_at' => now()->toIso8601String()],
+            86400
+        );
+
+        Log::info('Monthly report generated', [
+            'tenant_id' => $this->tenantId,
+            'period'    => "{$this->year}-{$this->month:02d}",
+            'count'     => $expenses->count(),
+            'path'      => $path,
+        ]);
+    }
+
+    private function generateCsv($expenses): string
+    {
+        $rows = [
+            ['経費番号', '件名', '申請者', '部門', '金額', 'ステータス', '申請日'],
+        ];
+
+        foreach ($expenses as $expense) {
+            $rows[] = [
+                $expense->expense_number,
+                $expense->title,
+                $expense->applicant?->name ?? '',
+                $expense->applicant?->department ?? '',
+                $expense->total_amount,
+                $expense->status,
+                $expense->created_at->format('Y-m-d'),
+            ];
+        }
+
+        $output = "\xEF\xBB\xBF"; // BOM for Excel
+        foreach ($rows as $row) {
+            $output .= implode(',', array_map(
+                fn($v) => '"' . str_replace('"', '""', (string) $v) . '"',
+                $row
+            )) . "\r\n";
+        }
+
+        return $output;
+    }
+}

--- a/expense-management/backend/app/Jobs/SendApprovalRequestEmail.php
+++ b/expense-management/backend/app/Jobs/SendApprovalRequestEmail.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Infrastructure\Persistence\Eloquent\Models\ExpenseModel;
+use App\Infrastructure\Persistence\Eloquent\Models\UserModel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendApprovalRequestEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int    $tries       = 3;
+    public int    $backoff     = 60;
+    public string $queue       = 'emails';
+
+    public function __construct(
+        private readonly string $expenseId,
+        private readonly string $approverUserId,
+    ) {}
+
+    public function handle(): void
+    {
+        $expense  = ExpenseModel::with('applicant')->find($this->expenseId);
+        $approver = UserModel::find($this->approverUserId);
+
+        if (!$expense || !$approver) {
+            Log::warning('SendApprovalRequestEmail: expense or approver not found', [
+                'expense_id'  => $this->expenseId,
+                'approver_id' => $this->approverUserId,
+            ]);
+            return;
+        }
+
+        Mail::send([], [], function ($message) use ($expense, $approver) {
+            $message
+                ->to($approver->email, $approver->name)
+                ->subject("「{$expense->title}」の承認依頼")
+                ->html($this->buildHtml($expense, $approver));
+        });
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        Log::error('SendApprovalRequestEmail failed', [
+            'expense_id'  => $this->expenseId,
+            'approver_id' => $this->approverUserId,
+            'error'       => $e->getMessage(),
+        ]);
+    }
+
+    private function buildHtml(ExpenseModel $expense, UserModel $approver): string
+    {
+        $appUrl     = config('app.url');
+        $detailUrl  = "{$appUrl}/expenses/{$expense->id}";
+        $amount     = number_format($expense->total_amount);
+        $applicant  = $expense->applicant?->name ?? '-';
+
+        return <<<HTML
+        <!DOCTYPE html>
+        <html lang="ja">
+        <head><meta charset="utf-8"></head>
+        <body style="font-family: sans-serif; color: #111;">
+          <p>{$approver->name} 様</p>
+          <p>以下の経費申請の承認をお願いします。</p>
+          <table border="0" cellpadding="8" style="border-collapse: collapse; margin: 16px 0;">
+            <tr><th style="text-align:left">件名</th><td>{$expense->title}</td></tr>
+            <tr><th style="text-align:left">申請者</th><td>{$applicant}</td></tr>
+            <tr><th style="text-align:left">金額</th><td>&yen;{$amount}</td></tr>
+          </table>
+          <p><a href="{$detailUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;text-decoration:none;border-radius:6px;">経費申請を確認する</a></p>
+        </body>
+        </html>
+        HTML;
+    }
+}


### PR DESCRIPTION
## Summary

- `SendApprovalRequestEmail.php`: 承認依頼メール送信ジョブ
  - キュー: `emails`、リトライ3回、バックオフ60秒
  - HTML メールで承認者に申請詳細と承認リンクを送信
  - 失敗時は `Log::error` でアラート
- `GenerateMonthlyReport.php`: 月次 CSV レポート生成ジョブ
  - キュー: `reports`、タイムアウト300秒
  - Excel 対応の BOM 付き UTF-8 CSV を S3 に保存
  - 生成完了を Redis にキャッシュ（24時間）

## キュー構成

| キュー名 | 用途 | ワーカー推奨数 |
|---------|------|--------------|
| `default` | 一般処理 | 2 |
| `emails` | メール送信 | 2 |
| `notifications` | 通知作成 | 1 |
| `reports` | CSV生成 | 1 |

## CSV 出力列

`経費番号, 件名, 申請者, 部門, 金額, ステータス, 申請日`

BOM 付き UTF-8 で Excel 文字化けを防止。

## Test plan

- [ ] `queue:work --queue=emails` で承認依頼メールが送信される
- [ ] 存在しない expense_id でジョブが安全に終了する（例外なし）
- [ ] 月次レポートが S3 の `reports/{tenantId}/{year}-{month}.csv` に保存される
- [ ] 生成済みレポートが Redis にキャッシュされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_