### PR TITLE
feat: Add mobile-optimized expense list with card layout and filter chips

### DIFF
--- a/expense-management/frontend/src/components/expense/ExpenseListMobile.tsx
+++ b/expense-management/frontend/src/components/expense/ExpenseListMobile.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useExpenses } from '../../hooks/useExpenses';
+import { MobileExpenseCard } from './MobileExpenseCard';
+import type { ExpenseSearchParams } from '../../types/expense';
+
+export function ExpenseListMobile() {
+  const [params, setParams] = useState<ExpenseSearchParams>({
+    page: 1,
+    per_page: 10,
+    sort_by: 'created_at',
+    sort_dir: 'desc',
+  });
+
+  const { data, isLoading, isError } = useExpenses(params);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      {/* トップバー */}
+      <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <h1 className="text-base font-semibold text-gray-900">経費申請</h1>
+          <Link
+            to="/expenses/new"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-full hover:bg-blue-700 active:bg-blue-800"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            新規申請
+          </Link>
+        </div>
+
+        {/* ステータスフィルター */}
+        <div className="flex gap-2 mt-3 overflow-x-auto pb-1 -mx-4 px-4 scrollbar-none">
+          {(['', 'draft', 'submitted', 'approved', 'rejected'] as const).map((status) => (
+            <button
+              key={status}
+              onClick={() =>
+                setParams((p) => ({ ...p, status: status || undefined, page: 1 }))
+              }
+              className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                (params.status ?? '') === status
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-600 border-gray-300'
+              }`}
+            >
+              {status === '' && 'すべて'}
+              {status === 'draft' && '下書き'}
+              {status === 'submitted' && '申請中'}
+              {status === 'approved' && '承認済'}
+              {status === 'rejected' && '却下'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* リスト */}
+      <div className="flex-1 p-4 space-y-3">
+        {isLoading ? (
+          Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-24 bg-white rounded-lg border border-gray-200 animate-pulse" />
+          ))
+        ) : isError ? (
+          <p className="text-center text-sm text-red-500 py-8">データの取得に失敗しました</p>
+        ) : data?.data.length === 0 ? (
+          <p className="text-center text-sm text-gray-500 py-12">申請データがありません</p>
+        ) : (
+          data?.data.map((expense) => (
+            <MobileExpenseCard key={expense.id} expense={expense} />
+          ))
+        )}
+      </div>
+
+      {/* ページネーション */}
+      {data && data.meta.last_page > 1 && (
+        <div className="sticky bottom-0 bg-white border-t border-gray-200 px-4 py-3 flex justify-between items-center">
+          <button
+            onClick={() => setParams((p) => ({ ...p, page: (p.page ?? 1) - 1 }))}
+            disabled={data.meta.current_page === 1}
+            className="px-4 py-2 text-sm border rounded-lg disabled:opacity-40"
+          >
+            ← 前へ
+          </button>
+          <span className="text-sm text-gray-500">
+            {data.meta.current_page} / {data.meta.last_page}
+          </span>
+          <button
+            onClick={() => setParams((p) => ({ ...p, page: (p.page ?? 1) + 1 }))}
+            disabled={data.meta.current_page === data.meta.last_page}
+            className="px-4 py-2 text-sm border rounded-lg disabled:opacity-40"
+          >
+            次へ →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/expense-management/frontend/src/components/expense/MobileExpenseCard.tsx
+++ b/expense-management/frontend/src/components/expense/MobileExpenseCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { STATUS_LABELS, STATUS_COLORS, type Expense } from '../../types/expense';
+
+interface Props {
+  expense: Expense;
+}
+
+export function MobileExpenseCard({ expense }: Props) {
+  return (
+    <Link
+      to={`/expenses/${expense.id}`}
+      className="block bg-white rounded-lg border border-gray-200 p-4 hover:border-blue-300 transition-colors active:bg-gray-50"
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <p className="text-sm font-medium text-gray-900 line-clamp-2 flex-1">
+          {expense.title}
+        </p>
+        <span
+          className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+            STATUS_COLORS[expense.status]
+          }`}
+        >
+          {STATUS_LABELS[expense.status]}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-gray-500 font-mono text-xs">
+          {expense.expense_number}
+        </span>
+        <span className="font-semibold text-gray-900">
+          {expense.total_amount_formatted}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between mt-2 text-xs text-gray-400">
+        <span>{expense.applicant?.name ?? '-'}</span>
+        <span>
+          {expense.applied_at
+            ? new Date(expense.applied_at).toLocaleDateString('ja-JP')
+            : new Date(expense.created_at).toLocaleDateString('ja-JP')}
+        </span>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- `MobileExpenseCard.tsx`: スマートフォン向けカードコンポーネント
  - タイトル・番号・金額・ステータスバッジ・申請者・日付を1カードに集約
  - `line-clamp-2` で長いタイトルを省略
  - `active:bg-gray-50` でタップフィードバック
- `ExpenseListMobile.tsx`: モバイル専用リストページ
  - ステータスフィルターをスクロール可能な横並びチップに変更（PCのセレクトボックスより操作しやすい）
  - スケルトンローディング（5枚のプレースホルダー）
  - スティッキーヘッダー + スティッキーページネーションフッター
  - per_page を10件に設定（モバイルの表示領域を考慮）

## レスポンシブ戦略

| 画面幅 | 使用コンポーネント |
|--------|-----------------|
| `< lg` (< 1024px) | `ExpenseListMobile` |
| `>= lg` (>= 1024px) | `ExpenseList`（既存のテーブル） |

## Test plan

- [ ] スマートフォン幅でカードレイアウトが表示される
- [ ] ステータスチップのタップでリストが絞り込まれる
- [ ] スケルトンがローディング中に表示される
- [ ] フッターのページネーションが正しく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_