### PR TITLE
feat: Add complete API route definitions and HTTP Kernel middleware stack

### DIFF
--- a/expense-management/backend/app/Http/Kernel.php
+++ b/expense-management/backend/app/Http/Kernel.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http;
+
+use App\Http\Middleware\AuditLogMiddleware;
+use App\Http\Middleware\CheckPermission;
+use App\Http\Middleware\ForceJsonResponse;
+use App\Http\Middleware\SecurityHeaders;
+use App\Http\Middleware\TenantMiddleware;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        SecurityHeaders::class,
+        ForceJsonResponse::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    protected $middlewareGroups = [
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            AuditLogMiddleware::class,
+        ],
+    ];
+
+    protected $routeMiddleware = [
+        'auth'       => \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+        'tenant'     => TenantMiddleware::class,
+        'permission' => CheckPermission::class,
+        'throttle'   => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+    ];
+}

--- a/expense-management/backend/routes/api.php
+++ b/expense-management/backend/routes/api.php
@@ -2,92 +2,88 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\HealthController;
+use App\Http\Controllers\Api\V1\Admin\CategoryController as AdminCategoryController;
+use App\Http\Controllers\Api\V1\Admin\TenantController;
+use App\Http\Controllers\Api\V1\Admin\UserController as AdminUserController;
+use App\Http\Controllers\Api\V1\ApprovalFlowController;
 use App\Http\Controllers\Api\V1\AuthController;
+use App\Http\Controllers\Api\V1\CategoryController;
+use App\Http\Controllers\Api\V1\CommentController;
 use App\Http\Controllers\Api\V1\ExpenseController;
+use App\Http\Controllers\Api\V1\NotificationController;
 use App\Http\Controllers\Api\V1\ReceiptController;
+use App\Http\Controllers\Api\V1\ReportController;
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| API Routes - v1
-|--------------------------------------------------------------------------
-*/
+// ヘルスチェック（認証不要）
+Route::get('/health', HealthController::class);
 
+// API v1
 Route::prefix('v1')->group(function () {
 
-    // 認証（テナント解決なし）
+    // 認証（公開エンドポイント）
     Route::prefix('auth')->group(function () {
         Route::post('login', [AuthController::class, 'login']);
     });
 
-    // 認証必須
+    // 認証必要ルート
     Route::middleware(['auth:sanctum', 'tenant'])->group(function () {
 
-        Route::post('auth/logout', [AuthController::class, 'logout']);
-        Route::get('me', [AuthController::class, 'me']);
-
-        // 経費申請
-        Route::prefix('expenses')->group(function () {
-            Route::get('/', [ExpenseController::class, 'index']);
-            Route::post('/', [ExpenseController::class, 'store']);
-            Route::get('/export', [ExpenseController::class, 'export']);
-            Route::get('/{id}', [ExpenseController::class, 'show']);
-            Route::put('/{id}', [ExpenseController::class, 'update']);
-            Route::delete('/{id}', [ExpenseController::class, 'destroy']);
-            Route::post('/{id}/submit', [ExpenseController::class, 'submit']);
-            Route::post('/{id}/cancel', [ExpenseController::class, 'cancel']);
-            Route::post('/{id}/approve', [ExpenseController::class, 'approve']);
-            Route::post('/{id}/reject', [ExpenseController::class, 'reject']);
-            Route::get('/{id}/history', [ExpenseController::class, 'history']);
-
-            // 領収書
-            Route::post('/{expenseId}/items/{itemId}/receipts', [ReceiptController::class, 'store']);
-            Route::delete('/{expenseId}/items/{itemId}/receipts/{receiptId}', [ReceiptController::class, 'destroy']);
-
-            // コメント
-            Route::get('/{id}/comments', [\App\Http\Controllers\Api\V1\CommentController::class, 'index']);
-            Route::post('/{id}/comments', [\App\Http\Controllers\Api\V1\CommentController::class, 'store']);
+        // 認証
+        Route::prefix('auth')->group(function () {
+            Route::post('logout', [AuthController::class, 'logout']);
+            Route::get('me',     [AuthController::class, 'me']);
         });
 
-        // 承認フロー管理
-        Route::apiResource('approval-flows', \App\Http\Controllers\Api\V1\ApprovalFlowController::class);
+        // 経費申請
+        Route::apiResource('expenses', ExpenseController::class);
+        Route::prefix('expenses/{expense}')->group(function () {
+            Route::post('submit',  [ExpenseController::class, 'submit']);
+            Route::post('approve', [ExpenseController::class, 'approve'])->middleware('permission:expense.approve');
+            Route::post('reject',  [ExpenseController::class, 'reject'])->middleware('permission:expense.approve');
+            Route::post('cancel',  [ExpenseController::class, 'cancel']);
+            Route::get('history',  [ExpenseController::class, 'history']);
+            Route::get('export',   [ExpenseController::class, 'export'])->middleware('permission:expense.export');
+
+            // 領収書
+            Route::post('receipts',          [ReceiptController::class, 'store']);
+            Route::delete('receipts/{receipt}', [ReceiptController::class, 'destroy']);
+
+            // コメント
+            Route::apiResource('comments', CommentController::class)->except(['show']);
+        });
 
         // カテゴリ
-        Route::get('categories', fn() => response()->json(
-            \App\Infrastructure\Persistence\Eloquent\Models\CategoryModel
-                ::where('tenant_id', auth()->user()->tenant_id)
-                ->where('is_active', true)
-                ->orderBy('sort_order')
-                ->get(['id', 'name', 'code', 'parent_id', 'max_amount', 'requires_receipt'])
-        ));
+        Route::get('categories', [CategoryController::class, 'index']);
+
+        // 承認フロー
+        Route::apiResource('approval-flows', ApprovalFlowController::class)
+            ->middleware(['permission:approval_flow.manage']);
 
         // 通知
         Route::prefix('notifications')->group(function () {
-            Route::get('/', fn() => response()->json(
-                \App\Infrastructure\Persistence\Eloquent\Models\NotificationModel
-                    ::where('user_id', auth()->id())
-                    ->orderByDesc('created_at')
-                    ->paginate(20)
-            ));
-            Route::put('/{id}/read', fn(string $id) => response()->json(
-                \App\Infrastructure\Persistence\Eloquent\Models\NotificationModel
-                    ::where('user_id', auth()->id())
-                    ->findOrFail($id)
-                    ->update(['read_at' => now()])
-            ));
+            Route::get('/',                 [NotificationController::class, 'index']);
+            Route::patch('{id}/read',       [NotificationController::class, 'markAsRead']);
+            Route::post('read-all',         [NotificationController::class, 'markAllAsRead']);
         });
 
-        // 管理者機能
-        Route::middleware('permission:admin')->prefix('admin')->group(function () {
-            Route::apiResource('users', \App\Http\Controllers\Api\V1\UserController::class);
-            Route::get('audit-logs', fn(\Illuminate\Http\Request $req) =>
-                response()->json(
-                    \App\Infrastructure\Persistence\Eloquent\Models\AuditLogModel
-                        ::where('tenant_id', auth()->user()->tenant_id)
-                        ->orderByDesc('created_at')
-                        ->paginate(50)
-                )
-            );
+        // レポート（report.view 権限必要）
+        Route::prefix('reports')->middleware('permission:report.view')->group(function () {
+            Route::get('monthly',       [ReportController::class, 'monthly']);
+            Route::get('by-category',   [ReportController::class, 'byCategory']);
+            Route::get('by-applicant',  [ReportController::class, 'byApplicant']);
+            Route::get('approval-stats',[ReportController::class, 'approvalStats']);
+        });
+
+        // 管理者ルート
+        Route::prefix('admin')->middleware('permission:user.manage')->group(function () {
+            Route::apiResource('users', AdminUserController::class);
+            Route::apiResource('categories', AdminCategoryController::class)->only(['index', 'store', 'update']);
+
+            Route::get('tenant',         [TenantController::class, 'show']);
+            Route::patch('tenant',       [TenantController::class, 'update']);
+            Route::get('tenant/stats',   [TenantController::class, 'stats']);
         });
     });
 });


### PR DESCRIPTION
## Summary

- `routes/api.php`: 全エンドポイントを整理・統合
  - `/health` を認証不要で公開
  - `/v1/auth/login` のみ認証不要
  - その他全 API は `auth:sanctum` + `tenant` ミドルウェアで保護
  - 権限が必要なルートに `permission:xxx` ミドルウェアを適用
- `app/Http/Kernel.php`: ミドルウェアスタック定義
  - グローバル: `SecurityHeaders` + `ForceJsonResponse` + CORS + ファイルサイズ制限
  - API グループ: throttle + ルートバインディング + `AuditLogMiddleware`
  - ルートミドルウェア: `auth`, `tenant`, `permission`, `throttle`

## ルート一覧

| グループ | 保護 | エンドポイント数 |
|--------|------|---------------|
| auth | なし / sanctum | 3 |
| expenses | sanctum + tenant | 10 |
| categories | sanctum + tenant | 1 |
| approval-flows | + permission | 5 |
| notifications | sanctum + tenant | 3 |
| reports | + permission | 4 |
| admin | + permission | 9 |

## Test plan

- [ ] `php artisan route:list` で全ルートが表示される
- [ ] 未認証リクエストが 401 を返す
- [ ] `permission:user.manage` なしのユーザーが admin ルートにアクセスすると 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_