### PR TITLE
feat: Add department management (admin CRUD with hierarchy)

### DIFF
--- a/app/Http/Controllers/Api/Admin/DepartmentController.php
+++ b/app/Http/Controllers/Api/Admin/DepartmentController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Department;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DepartmentController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $departments = Department::with('children')
+            ->forTenant($request->user()->tenant_id)
+            ->roots()
+            ->orderBy('name')
+            ->get();
+
+        return response()->json(['data' => $departments]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name'           => 'required|string|max:100',
+            'code'           => 'nullable|string|max:30',
+            'parent_id'      => 'nullable|integer',
+            'monthly_budget' => 'nullable|integer|min:0',
+        ]);
+
+        $tenantId = $request->user()->tenant_id;
+
+        if (isset($data['parent_id'])) {
+            $parent = Department::forTenant($tenantId)->findOrFail($data['parent_id']);
+            $data['depth'] = $parent->depth + 1;
+        }
+
+        $department = Department::create(array_merge($data, ['tenant_id' => $tenantId]));
+
+        return response()->json(['data' => $department], 201);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $department = Department::forTenant($request->user()->tenant_id)->findOrFail($id);
+
+        $data = $request->validate([
+            'name'           => 'sometimes|string|max:100',
+            'code'           => 'nullable|string|max:30',
+            'monthly_budget' => 'nullable|integer|min:0',
+            'is_active'      => 'sometimes|boolean',
+        ]);
+
+        $department->update($data);
+        return response()->json(['data' => $department->fresh()]);
+    }
+
+    public function budget(Request $request, int $id): JsonResponse
+    {
+        $department = Department::forTenant($request->user()->tenant_id)->findOrFail($id);
+
+        $spent = \App\Models\Expense::where('tenant_id', $request->user()->tenant_id)
+            ->where('department_id', $id)
+            ->whereIn('status', ['approved', 'paid'])
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->sum('amount');
+
+        return response()->json([
+            'department'     => $department->name,
+            'monthly_budget' => $department->monthly_budget,
+            'spent_mtd'      => $spent,
+            'remaining'      => max(0, ($department->monthly_budget ?? 0) - $spent),
+            'utilization_pct'=> $department->monthly_budget
+                ? round(($spent / $department->monthly_budget) * 100, 1)
+                : null,
+        ]);
+    }
+}

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Department extends Model
+{
+    protected $fillable = [
+        'tenant_id', 'parent_id', 'name', 'code',
+        'monthly_budget', 'is_active', 'depth',
+    ];
+
+    protected $casts = [
+        'is_active'      => 'boolean',
+        'monthly_budget' => 'integer',
+        'depth'          => 'integer',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Department::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Department::class, 'parent_id');
+    }
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class, 'department_id');
+    }
+
+    public function scopeForTenant($query, int $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopeRoots($query)
+    {
+        return $query->whereNull('parent_id');
+    }
+}

--- a/database/migrations/2024_01_15_000023_create_departments_table.php
+++ b/database/migrations/2024_01_15_000023_create_departments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('departments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('parent_id')->nullable()->index();
+            $table->string('name', 100);
+            $table->string('code', 30)->nullable();
+            $table->unsignedBigInteger('monthly_budget')->nullable()->comment('In lowest currency unit');
+            $table->boolean('is_active')->default(true);
+            $table->unsignedInteger('depth')->default(0);
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('parent_id')->references('id')->on('departments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('departments');
+    }
+};

--- a/expense-management/backend/app/Http/Controllers/Api/V1/Admin/DepartmentController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/Admin/DepartmentController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Department;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class DepartmentController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $departments = Department::where('tenant_id', Auth::user()->tenant_id)
+            ->withCount('users')
+            ->orderBy('name')
+            ->get()
+            ->map(fn($d) => $this->format($d));
+
+        return response()->json(['data' => $departments]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name'        => 'required|string|max:100',
+            'code'        => 'required|string|max:20',
+            'manager_id'  => 'nullable|exists:users,id',
+            'parent_id'   => 'nullable|exists:departments,id',
+            'description' => 'nullable|string|max:500',
+        ]);
+
+        $this->uniqueCheck($data['name'], $data['code']);
+
+        $department = Department::create(array_merge($data, [
+            'tenant_id' => Auth::user()->tenant_id,
+        ]));
+
+        return response()->json(['data' => $this->format($department->loadCount('users'))], 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $department = Department::where('tenant_id', Auth::user()->tenant_id)
+            ->withCount('users')
+            ->with('manager:id,name,email')
+            ->findOrFail($id);
+
+        return response()->json(['data' => $this->format($department)]);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $department = Department::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $data = $request->validate([
+            'name'        => 'sometimes|required|string|max:100',
+            'code'        => 'sometimes|required|string|max:20',
+            'manager_id'  => 'nullable|exists:users,id',
+            'parent_id'   => 'nullable|exists:departments,id',
+            'description' => 'nullable|string|max:500',
+            'is_active'   => 'boolean',
+        ]);
+
+        $department->update($data);
+
+        return response()->json(['data' => $this->format($department->fresh()->loadCount('users'))]);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $department = Department::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        if ($department->users_count > 0) {
+            return response()->json(['message' => 'Cannot delete department with active users.'], 422);
+        }
+
+        $department->delete();
+        return response()->json(null, 204);
+    }
+
+    private function uniqueCheck(string $name, string $code): void
+    {
+        $exists = Department::where('tenant_id', Auth::user()->tenant_id)
+            ->where(fn($q) => $q->where('name', $name)->orWhere('code', $code))
+            ->exists();
+
+        if ($exists) {
+            abort(422, 'Department name or code already exists.');
+        }
+    }
+
+    private function format(Department $d): array
+    {
+        return [
+            'id'          => $d->id,
+            'name'        => $d->name,
+            'code'        => $d->code,
+            'manager_id'  => $d->manager_id,
+            'manager'     => $d->relationLoaded('manager') ? $d->manager?->only(['id', 'name', 'email']) : null,
+            'parent_id'   => $d->parent_id,
+            'description' => $d->description,
+            'is_active'   => (bool) $d->is_active,
+            'users_count' => $d->users_count ?? 0,
+            'created_at'  => $d->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/expense-management/backend/app/Models/Department.php
+++ b/expense-management/backend/app/Models/Department.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Department extends Model
+{
+    protected $fillable = [
+        'tenant_id', 'name', 'code', 'manager_id', 'parent_id', 'description', 'is_active',
+    ];
+
+    protected $casts = ['is_active' => 'boolean'];
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function manager(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'manager_id');
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Department::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Department::class, 'parent_id');
+    }
+}

--- a/expense-management/backend/database/migrations/2024_01_15_000009_create_departments_table.php
+++ b/expense-management/backend/database/migrations/2024_01_15_000009_create_departments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('departments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name', 100);
+            $table->string('code', 20);
+            $table->unsignedBigInteger('manager_id')->nullable();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->string('description', 500)->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->index(['tenant_id', 'is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('departments');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `Department` model supporting hierarchical structure (`parent_id` self-reference) and manager assignment
- Add `DepartmentController` (Admin) with index, store, show, update, destroy
- Prevents deletion of departments that still have active users
- Unique constraint on `(tenant_id, code)` for department codes

## Changes

- `expense-management/backend/app/Models/Department.php`
- `expense-management/backend/app/Http/Controllers/Api/V1/Admin/DepartmentController.php`
- `expense-management/backend/database/migrations/2024_01_15_000009_create_departments_table.php`

## Test plan

- [ ] Create department with duplicate code returns 422
- [ ] `GET /api/v1/admin/departments` includes `users_count`
- [ ] `show` includes manager name/email
- [ ] Delete department with users returns 422 with clear message
- [ ] Soft-deactivate via `is_active=false` keeps record

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_