### PR TITLE
feat: Add SNS alerts + CloudWatch metric alarms (Terraform)

### DIFF
--- a/expense-management/terraform/sns_alerts.tf
+++ b/expense-management/terraform/sns_alerts.tf
@@ -1,0 +1,179 @@
+# SNS topic for ops alerts
+resource "aws_sns_topic" "alerts" {
+  name              = "${local.name_prefix}-alerts"
+  kms_master_key_id = "alias/aws/sns"
+
+  tags = local.common_tags
+}
+
+resource "aws_sns_topic_subscription" "alerts_email" {
+  count     = var.alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# ---------- ECS alarms ----------
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "${local.name_prefix}-ecs-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS CPU > 80% for 2 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.api.name
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "${local.name_prefix}-ecs-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 85
+  alarm_description   = "ECS Memory > 85% for 2 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.api.name
+  }
+
+  tags = local.common_tags
+}
+
+# ---------- RDS alarms ----------
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
+  alarm_name          = "${local.name_prefix}-rds-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 70
+  alarm_description   = "RDS CPU > 70% for 3 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "${local.name_prefix}-rds-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 150
+  alarm_description   = "RDS connections > 150"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage" {
+  alarm_name          = "${local.name_prefix}-rds-free-storage-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeLocalStorage"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 5368709120 # 5 GiB
+  alarm_description   = "RDS free storage < 5 GiB"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+# ---------- ALB alarms ----------
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_high" {
+  alarm_name          = "${local.name_prefix}-alb-5xx-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 20
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ALB 5xx count > 20/min for 2 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = aws_alb.main.arn_suffix
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency_high" {
+  alarm_name          = "${local.name_prefix}-alb-latency-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  extended_statistic  = "p95"
+  threshold           = 3
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ALB p95 latency > 3s for 3 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = aws_alb.main.arn_suffix
+  }
+
+  tags = local.common_tags
+}
+
+# ---------- ElastiCache alarms ----------
+resource "aws_cloudwatch_metric_alarm" "redis_memory_high" {
+  alarm_name          = "${local.name_prefix}-redis-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "Redis memory usage > 80%"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ReplicationGroupId = aws_elasticache_replication_group.main.replication_group_id
+  }
+
+  tags = local.common_tags
+}

--- a/expense-management/terraform/variables_alerts.tf
+++ b/expense-management/terraform/variables_alerts.tf
@@ -1,0 +1,5 @@
+variable "alert_email" {
+  description = "Email address to receive CloudWatch alarm notifications (empty to skip)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Terraform resources for SNS topic (KMS-encrypted) with optional email subscription
- 8 CloudWatch metric alarms covering all critical infrastructure dimensions:
  - **ECS**: CPU > 80%, Memory > 85%
  - **RDS**: CPU > 70%, Connections > 150, Free storage < 5 GiB
  - **ALB**: 5xx count > 20/min, p95 latency > 3s
  - **ElastiCache**: Memory usage > 80%
- `alert_email` variable (empty = skip email subscription)

## Changes

- `expense-management/terraform/sns_alerts.tf`
- `expense-management/terraform/variables_alerts.tf`

## Test plan

- [ ] `terraform plan` shows SNS topic, subscription (when email set), and 8 alarms
- [ ] Alarm actions point to the correct SNS topic ARN
- [ ] `treat_missing_data = notBreaching` on count-based alarms prevents false positives during quiet periods

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_