### PR TITLE
feat: Add outbound webhook system with HMAC signature and retry

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/Admin/WebhookController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/Admin/WebhookController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class WebhookController extends Controller
+{
+    private const ALLOWED_EVENTS = [
+        'expense.submitted', 'expense.approved', 'expense.rejected',
+        'expense.paid', 'user.created', '*',
+    ];
+
+    public function index(): JsonResponse
+    {
+        $hooks = Webhook::where('tenant_id', Auth::user()->tenant_id)
+            ->withCount('deliveries')
+            ->orderByDesc('created_at')
+            ->get();
+
+        return response()->json(['data' => $hooks]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'url'    => 'required|url|max:500',
+            'events' => 'required|array|min:1',
+            'events.*' => 'string|in:' . implode(',', self::ALLOWED_EVENTS),
+        ]);
+
+        $hook = Webhook::create([
+            'tenant_id' => Auth::user()->tenant_id,
+            'url'       => $data['url'],
+            'events'    => array_unique($data['events']),
+            'secret'    => Str::random(40),
+            'is_active' => true,
+        ]);
+
+        return response()->json(['data' => $hook->makeVisible('secret')], 201);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $hook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $data = $request->validate([
+            'url'       => 'sometimes|url|max:500',
+            'events'    => 'sometimes|array|min:1',
+            'events.*'  => 'string|in:' . implode(',', self::ALLOWED_EVENTS),
+            'is_active' => 'boolean',
+        ]);
+
+        $hook->update($data);
+        return response()->json(['data' => $hook->fresh()]);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id)->delete();
+        return response()->json(null, 204);
+    }
+
+    public function rotateSecret(int $id): JsonResponse
+    {
+        $hook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+        $hook->update(['secret' => Str::random(40), 'failure_count' => 0]);
+        return response()->json(['data' => $hook->fresh()->makeVisible('secret')]);
+    }
+}

--- a/expense-management/backend/app/Jobs/DispatchWebhook.php
+++ b/expense-management/backend/app/Jobs/DispatchWebhook.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class DispatchWebhook implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly int $webhookId,
+        private readonly string $event,
+        private readonly array $payload,
+    ) {
+        $this->onQueue('notifications');
+    }
+
+    public function handle(): void
+    {
+        $webhook = Webhook::find($this->webhookId);
+
+        if (!$webhook || !$webhook->is_active) {
+            return;
+        }
+
+        $body    = json_encode($this->payload, JSON_UNESCAPED_UNICODE);
+        $sig     = hash_hmac('sha256', $body, $webhook->secret);
+        $attempt = $this->attempts();
+
+        $response = Http::timeout(10)
+            ->withHeaders([
+                'Content-Type'           => 'application/json',
+                'X-Webhook-Event'        => $this->event,
+                'X-Webhook-Signature'    => "sha256={$sig}",
+                'X-Webhook-Delivery-Id'  => uniqid('wh_', true),
+            ])
+            ->post($webhook->url, $this->payload);
+
+        $success = $response->successful();
+
+        WebhookDelivery::create([
+            'webhook_id'    => $webhook->id,
+            'event'         => $this->event,
+            'payload'       => $this->payload,
+            'status_code'   => $response->status(),
+            'success'       => $success,
+            'response_body' => substr($response->body(), 0, 2000),
+            'attempt'       => $attempt,
+        ]);
+
+        $webhook->update([
+            'last_triggered_at' => now(),
+            'failure_count'     => $success ? 0 : $webhook->failure_count + 1,
+        ]);
+
+        if (!$success) {
+            $this->release($this->backoff * $attempt);
+        }
+    }
+}

--- a/expense-management/backend/app/Models/Webhook.php
+++ b/expense-management/backend/app/Models/Webhook.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Webhook extends Model
+{
+    protected $fillable = [
+        'tenant_id', 'url', 'secret', 'events', 'is_active',
+    ];
+
+    protected $casts = [
+        'events'    => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    protected $hidden = ['secret'];
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    public function subscribesTo(string $event): bool
+    {
+        return in_array($event, $this->events, true) || in_array('*', $this->events, true);
+    }
+}

--- a/expense-management/backend/database/migrations/2024_01_15_000011_create_webhooks_table.php
+++ b/expense-management/backend/database/migrations/2024_01_15_000011_create_webhooks_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('url');
+            $table->string('secret', 64);
+            $table->json('events');
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('last_triggered_at')->nullable();
+            $table->unsignedSmallInteger('failure_count')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('webhook_id')->index();
+            $table->string('event');
+            $table->json('payload');
+            $table->unsignedSmallInteger('status_code')->nullable();
+            $table->boolean('success')->default(false);
+            $table->text('response_body')->nullable();
+            $table->unsignedSmallInteger('attempt')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+        Schema::dropIfExists('webhooks');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `webhooks` and `webhook_deliveries` tables via migration
- `Webhook` model with per-tenant event subscriptions (`events` JSON array) and hidden `secret`
- `DispatchWebhook` queued job — signs payload with HMAC-SHA256, POSTs to subscriber URL, records delivery result, releases back to queue on failure (exponential backoff: 60s × attempt)
- `WebhookController` (Admin) — CRUD + `rotateSecret` endpoint to regenerate the signing key
- Wildcard subscription via `events: ["*"]`

## Changes

- `expense-management/backend/database/migrations/2024_01_15_000011_create_webhooks_table.php`
- `expense-management/backend/app/Models/Webhook.php`
- `expense-management/backend/app/Jobs/DispatchWebhook.php`
- `expense-management/backend/app/Http/Controllers/Api/V1/Admin/WebhookController.php`

## Test plan

- [ ] Creating a webhook returns 201 with secret visible only on first creation
- [ ] `rotateSecret` returns new secret; old deliveries retain their original signature
- [ ] Failed POST increments `failure_count`; success resets it to 0
- [ ] Delivery record is created regardless of HTTP outcome
- [ ] Cross-tenant — tenant A cannot read/delete tenant B webhooks

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_