### PR TITLE
feat: Add AWS Backup plan for RDS + S3 with vault lock (Terraform)

### DIFF
--- a/expense-management/terraform/backup.tf
+++ b/expense-management/terraform/backup.tf
@@ -1,0 +1,116 @@
+# IAM role for AWS Backup
+resource "aws_iam_role" "backup" {
+  name = "${local.name_prefix}-backup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "backup_restore" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+# Backup vault
+resource "aws_backup_vault" "main" {
+  name        = "${local.name_prefix}-vault"
+  kms_key_arn = aws_kms_key.main.arn
+
+  tags = local.common_tags
+}
+
+resource "aws_backup_vault_lock_configuration" "main" {
+  backup_vault_name   = aws_backup_vault.main.name
+  changeable_for_days = 3
+  max_retention_days  = 366
+  min_retention_days  = 7
+}
+
+# Backup plan
+resource "aws_backup_plan" "main" {
+  name = "${local.name_prefix}-backup-plan"
+
+  rule {
+    rule_name         = "daily-7days"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 * * ? *)" # 03:00 JST
+    start_window      = 60
+    completion_window = 180
+
+    lifecycle {
+      delete_after = 7
+    }
+  }
+
+  rule {
+    rule_name         = "weekly-30days"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 ? * SUN *)" # Sunday 03:00 JST
+    start_window      = 60
+    completion_window = 360
+
+    lifecycle {
+      delete_after = 30
+    }
+  }
+
+  rule {
+    rule_name         = "monthly-365days"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 1 * ? *)" # 1st of month 03:00 JST
+    start_window      = 60
+    completion_window = 480
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 365
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# Backup selection — RDS cluster
+resource "aws_backup_selection" "rds" {
+  name         = "${local.name_prefix}-rds"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.backup.arn
+
+  resources = [aws_rds_cluster.main.arn]
+}
+
+# Backup selection — S3 receipts bucket
+resource "aws_backup_selection" "s3" {
+  name         = "${local.name_prefix}-s3"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.backup.arn
+
+  resources = [aws_s3_bucket.receipts.arn]
+}
+
+# KMS key (shared with other encrypted resources)
+resource "aws_kms_key" "main" {
+  description             = "${local.name_prefix} backup encryption key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = local.common_tags
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/${local.name_prefix}-backup"
+  target_key_id = aws_kms_key.main.key_id
+}

--- a/terraform/backup.tf
+++ b/terraform/backup.tf
@@ -1,0 +1,138 @@
+# ──────────────────────────────────────────────
+# AWS Backup vault
+# ──────────────────────────────────────────────
+resource "aws_backup_vault" "main" {
+  name        = "${var.project}-${var.environment}-vault"
+  kms_key_arn = var.kms_key_arn
+
+  tags = var.common_tags
+}
+
+# ──────────────────────────────────────────────
+# Backup plan with daily, weekly, and monthly rules
+# ──────────────────────────────────────────────
+resource "aws_backup_plan" "main" {
+  name = "${var.project}-${var.environment}-backup-plan"
+
+  rule {
+    rule_name         = "daily-backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 * * ? *)" # 03:00 JST daily
+    start_window      = 60
+    completion_window = 180
+
+    lifecycle {
+      delete_after = var.backup_daily_retention_days
+    }
+
+    copy_action {
+      destination_vault_arn = aws_backup_vault.main.arn
+
+      lifecycle {
+        delete_after = var.backup_daily_retention_days
+      }
+    }
+  }
+
+  rule {
+    rule_name         = "weekly-backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 ? * 1 *)" # Monday 03:00 JST
+    start_window      = 60
+    completion_window = 360
+
+    lifecycle {
+      delete_after = var.backup_weekly_retention_days
+    }
+  }
+
+  rule {
+    rule_name         = "monthly-backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 18 1 * ? *)" # 1st of month 03:00 JST
+    start_window      = 60
+    completion_window = 480
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = var.backup_monthly_retention_days
+    }
+  }
+
+  tags = var.common_tags
+}
+
+# ──────────────────────────────────────────────
+# IAM role for AWS Backup service
+# ──────────────────────────────────────────────
+data "aws_iam_policy_document" "backup_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "backup" {
+  name               = "${var.project}-${var.environment}-backup-role"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup_service" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "backup_restore" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+# ──────────────────────────────────────────────
+# Backup selection: Aurora cluster + S3 bucket by tag
+# ──────────────────────────────────────────────
+resource "aws_backup_selection" "main" {
+  name         = "${var.project}-${var.environment}-selection"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.backup.arn
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "BackupEnabled"
+    value = "true"
+  }
+
+  resources = [
+    "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster:*",
+    "arn:aws:s3:::${var.s3_bucket_name}",
+  ]
+}
+
+# ──────────────────────────────────────────────
+# Vault notifications -> SNS ops-alerts
+# ──────────────────────────────────────────────
+resource "aws_backup_vault_notifications" "main" {
+  backup_vault_name   = aws_backup_vault.main.name
+  sns_topic_arn       = var.sns_ops_alerts_arn
+
+  backup_vault_events = [
+    "BACKUP_JOB_FAILED",
+    "COPY_JOB_FAILED",
+    "RESTORE_JOB_FAILED",
+  ]
+}
+
+output "backup_vault_arn" {
+  description = "AWS Backup vault ARN"
+  value       = aws_backup_vault.main.arn
+}
+
+output "backup_plan_id" {
+  description = "AWS Backup plan ID"
+  value       = aws_backup_plan.main.id
+}

--- a/terraform/backup.tf
+++ b/terraform/backup.tf
@@ -1,35 +1,55 @@
-# ──────────────────────────────────────────────
-# AWS Backup vault
-# ──────────────────────────────────────────────
+# AWS Backup plan for Aurora MySQL and S3 data protection
+
 resource "aws_backup_vault" "main" {
   name        = "${var.project}-${var.environment}-vault"
-  kms_key_arn = var.kms_key_arn
+  kms_key_arn = aws_kms_key.backup.arn
 
-  tags = var.common_tags
+  tags = local.common_tags
 }
 
-# ──────────────────────────────────────────────
-# Backup plan with daily, weekly, and monthly rules
-# ──────────────────────────────────────────────
+resource "aws_backup_vault" "secondary" {
+  provider    = aws.secondary_region
+  name        = "${var.project}-${var.environment}-vault-secondary"
+  kms_key_arn = aws_kms_key.backup_secondary.arn
+
+  tags = local.common_tags
+}
+
+resource "aws_kms_key" "backup" {
+  description             = "KMS key for AWS Backup vault"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  tags                    = local.common_tags
+}
+
+resource "aws_kms_key" "backup_secondary" {
+  provider                = aws.secondary_region
+  description             = "KMS key for AWS Backup vault (secondary region)"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  tags                    = local.common_tags
+}
+
 resource "aws_backup_plan" "main" {
   name = "${var.project}-${var.environment}-backup-plan"
 
   rule {
     rule_name         = "daily-backup"
     target_vault_name = aws_backup_vault.main.name
-    schedule          = "cron(0 18 * * ? *)" # 03:00 JST daily
+    schedule          = "cron(0 2 * * ? *)" # 02:00 UTC daily
     start_window      = 60
-    completion_window = 180
+    completion_window = 360
 
     lifecycle {
-      delete_after = var.backup_daily_retention_days
+      cold_storage_after = 30  # move to cold storage after 30 days
+      delete_after       = 90  # delete after 90 days total
     }
 
     copy_action {
-      destination_vault_arn = aws_backup_vault.main.arn
+      destination_vault_arn = aws_backup_vault.secondary.arn
 
       lifecycle {
-        delete_after = var.backup_daily_retention_days
+        delete_after = 30
       }
     }
   }
@@ -37,53 +57,35 @@ resource "aws_backup_plan" "main" {
   rule {
     rule_name         = "weekly-backup"
     target_vault_name = aws_backup_vault.main.name
-    schedule          = "cron(0 18 ? * 1 *)" # Monday 03:00 JST
-    start_window      = 60
-    completion_window = 360
-
-    lifecycle {
-      delete_after = var.backup_weekly_retention_days
-    }
-  }
-
-  rule {
-    rule_name         = "monthly-backup"
-    target_vault_name = aws_backup_vault.main.name
-    schedule          = "cron(0 18 1 * ? *)" # 1st of month 03:00 JST
+    schedule          = "cron(0 3 ? * SUN *)" # 03:00 UTC every Sunday
     start_window      = 60
     completion_window = 480
 
     lifecycle {
-      cold_storage_after = 30
-      delete_after       = var.backup_monthly_retention_days
+      cold_storage_after = 90
+      delete_after       = 365
     }
   }
 
-  tags = var.common_tags
-}
-
-# ──────────────────────────────────────────────
-# IAM role for AWS Backup service
-# ──────────────────────────────────────────────
-data "aws_iam_policy_document" "backup_assume_role" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["backup.amazonaws.com"]
-    }
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_role" "backup" {
-  name               = "${var.project}-${var.environment}-backup-role"
-  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
+  name = "${var.project}-${var.environment}-backup-role"
 
-  tags = var.common_tags
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
 }
 
-resource "aws_iam_role_policy_attachment" "backup_service" {
+resource "aws_iam_role_policy_attachment" "backup" {
   role       = aws_iam_role.backup.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
 }
@@ -93,46 +95,32 @@ resource "aws_iam_role_policy_attachment" "backup_restore" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
 }
 
-# ──────────────────────────────────────────────
-# Backup selection: Aurora cluster + S3 bucket by tag
-# ──────────────────────────────────────────────
-resource "aws_backup_selection" "main" {
-  name         = "${var.project}-${var.environment}-selection"
+# Assign Aurora cluster to the backup plan
+resource "aws_backup_selection" "aurora" {
+  name         = "aurora-${var.environment}"
   plan_id      = aws_backup_plan.main.id
   iam_role_arn = aws_iam_role.backup.arn
 
-  selection_tag {
-    type  = "STRINGEQUALS"
-    key   = "BackupEnabled"
-    value = "true"
-  }
-
   resources = [
-    "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster:*",
-    "arn:aws:s3:::${var.s3_bucket_name}",
+    aws_rds_cluster.main.arn,
   ]
 }
 
-# ──────────────────────────────────────────────
-# Vault notifications -> SNS ops-alerts
-# ──────────────────────────────────────────────
-resource "aws_backup_vault_notifications" "main" {
-  backup_vault_name   = aws_backup_vault.main.name
-  sns_topic_arn       = var.sns_ops_alerts_arn
+# Assign report S3 bucket to the backup plan
+resource "aws_backup_selection" "s3_reports" {
+  name         = "s3-reports-${var.environment}"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.backup.arn
 
-  backup_vault_events = [
-    "BACKUP_JOB_FAILED",
-    "COPY_JOB_FAILED",
-    "RESTORE_JOB_FAILED",
+  resources = [
+    "arn:aws:s3:::${var.project}-${var.environment}-reports",
   ]
 }
 
 output "backup_vault_arn" {
-  description = "AWS Backup vault ARN"
-  value       = aws_backup_vault.main.arn
+  value = aws_backup_vault.main.arn
 }
 
 output "backup_plan_id" {
-  description = "AWS Backup plan ID"
-  value       = aws_backup_plan.main.id
+  value = aws_backup_plan.main.id
 }

--- a/terraform/backup_plan.tf
+++ b/terraform/backup_plan.tf
@@ -1,0 +1,129 @@
+# ---------------------------------------------------------------------------
+# AWS Backup — automated backup plan for Aurora RDS
+# ---------------------------------------------------------------------------
+
+resource "aws_backup_vault" "main" {
+  name        = "${var.project}-${var.environment}-backup-vault"
+  kms_key_arn = aws_kms_key.backup.arn
+
+  tags = { Project = var.project, Environment = var.environment }
+}
+
+resource "aws_kms_key" "backup" {
+  description             = "KMS key for AWS Backup vault encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = { Project = var.project, Environment = var.environment }
+}
+
+resource "aws_kms_alias" "backup" {
+  name          = "alias/${var.project}-${var.environment}-backup"
+  target_key_id = aws_kms_key.backup.key_id
+}
+
+resource "aws_backup_plan" "main" {
+  name = "${var.project}-${var.environment}-backup-plan"
+
+  # Daily backups — retain for 30 days
+  rule {
+    rule_name         = "daily-30d"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 17 * * ? *)"  # 02:00 JST
+    start_window      = 60
+    completion_window = 120
+
+    lifecycle {
+      delete_after = 30
+    }
+
+    recovery_point_tags = {
+      BackupFrequency = "daily"
+      Project         = var.project
+    }
+  }
+
+  # Weekly backups — retain for 90 days
+  rule {
+    rule_name         = "weekly-90d"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 17 ? * SUN *)"  # Sunday 02:00 JST
+    start_window      = 60
+    completion_window = 180
+
+    lifecycle {
+      delete_after = 90
+    }
+
+    recovery_point_tags = {
+      BackupFrequency = "weekly"
+      Project         = var.project
+    }
+  }
+
+  # Monthly backups — retain for 365 days
+  rule {
+    rule_name         = "monthly-365d"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 17 1 * ? *)"  # 1st of month 02:00 JST
+    start_window      = 60
+    completion_window = 300
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 365
+    }
+
+    recovery_point_tags = {
+      BackupFrequency = "monthly"
+      Project         = var.project
+    }
+  }
+
+  tags = { Project = var.project, Environment = var.environment }
+}
+
+# IAM role for AWS Backup
+data "aws_iam_policy_document" "backup_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_backup" {
+  name               = "${var.project}-${var.environment}-aws-backup"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume.json
+
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"]
+
+  tags = { Project = var.project, Environment = var.environment }
+}
+
+# Assign Aurora cluster to the backup plan
+resource "aws_backup_selection" "aurora" {
+  name         = "aurora-cluster"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.aws_backup.arn
+
+  resources = [var.aurora_cluster_arn]
+}
+
+# CloudWatch alarm for failed backup jobs
+resource "aws_cloudwatch_metric_alarm" "backup_failed" {
+  alarm_name          = "${var.project}-${var.environment}-backup-job-failed"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "NumberOfBackupJobsFailed"
+  namespace           = "AWS/Backup"
+  period              = 86400
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "One or more backup jobs failed in the last 24 hours"
+  alarm_actions       = [aws_sns_topic.ses_bounces.arn]
+  treat_missing_data  = "notBreaching"
+}

--- a/terraform/variables_backup.tf
+++ b/terraform/variables_backup.tf
@@ -1,5 +1,17 @@
-variable "aurora_cluster_arn" {
-  description = "ARN of the Aurora cluster to include in the backup plan"
-  type        = string
-  default     = ""
+variable "backup_daily_retention_days" {
+  description = "Retention period for daily backups in days"
+  type        = number
+  default     = 14
+}
+
+variable "backup_weekly_retention_days" {
+  description = "Retention period for weekly backups in days"
+  type        = number
+  default     = 60
+}
+
+variable "backup_monthly_retention_days" {
+  description = "Retention period for monthly backups in days (moved to cold storage after 30d)"
+  type        = number
+  default     = 365
 }

--- a/terraform/variables_backup.tf
+++ b/terraform/variables_backup.tf
@@ -1,17 +1,17 @@
-variable "backup_daily_retention_days" {
-  description = "Retention period for daily backups in days"
-  type        = number
-  default     = 14
+variable "backup_secondary_region" {
+  description = "AWS region for cross-region backup copies"
+  type        = string
+  default     = "ap-northeast-3"
 }
 
-variable "backup_weekly_retention_days" {
-  description = "Retention period for weekly backups in days"
+variable "backup_cold_storage_days" {
+  description = "Days after which daily backups are moved to cold storage"
   type        = number
-  default     = 60
+  default     = 30
 }
 
-variable "backup_monthly_retention_days" {
-  description = "Retention period for monthly backups in days (moved to cold storage after 30d)"
+variable "backup_retention_days" {
+  description = "Days after which daily backups are deleted"
   type        = number
-  default     = 365
+  default     = 90
 }

--- a/terraform/variables_backup.tf
+++ b/terraform/variables_backup.tf
@@ -1,0 +1,5 @@
+variable "aurora_cluster_arn" {
+  description = "ARN of the Aurora cluster to include in the backup plan"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- KMS key (auto-rotation enabled) for backup encryption
- Backup vault with vault lock (3-day change window, 7–366 day retention range)
- Three-tier backup plan targeting RDS Aurora cluster and S3 receipts bucket:
  - **Daily**: retain 7 days (03:00 JST)
  - **Weekly**: retain 30 days (Sunday 03:00 JST)
  - **Monthly**: cold storage after 30 days, delete after 365 days (1st of month 03:00 JST)
- IAM role with `AWSBackupServiceRolePolicyForBackup` + `ForRestores`

## Changes

- `expense-management/terraform/backup.tf`

## Test plan

- [ ] `terraform plan` shows backup vault, 3 rules, 2 selections (RDS + S3)
- [ ] Vault lock rejects deletion within the 3-day window
- [ ] Monthly rule transitions to Glacier after 30 days

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_