### PR TITLE
feat: Add approval policy service with amount-threshold routing

### DIFF
--- a/expense-management/backend/app/Services/ApprovalPolicyService.php
+++ b/expense-management/backend/app/Services/ApprovalPolicyService.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ApprovalFlow;
+use App\Models\Expense;
+
+class ApprovalPolicyService
+{
+    /**
+     * Resolve the approval flow that should handle this expense.
+     * Rules evaluated in priority order (lower number = higher priority).
+     */
+    public function resolveFlow(Expense $expense): ?ApprovalFlow
+    {
+        $tenantId = $expense->tenant_id;
+        $amount   = $expense->total_amount;
+
+        return ApprovalFlow::where('tenant_id', $tenantId)
+            ->where('is_active', true)
+            ->where(fn($q) =>
+                $q->whereNull('min_amount')->orWhere('min_amount', '<=', $amount)
+            )
+            ->where(fn($q) =>
+                $q->whereNull('max_amount')->orWhere('max_amount', '>=', $amount)
+            )
+            ->where(fn($q) =>
+                $q->whereNull('department_id')
+                  ->orWhere('department_id', $expense->department_id)
+            )
+            ->where(fn($q) =>
+                $q->whereNull('category_id')
+                  ->orWhere('category_id', $expense->category_id)
+            )
+            ->orderBy('priority')
+            ->first();
+    }
+
+    /**
+     * Build the ordered list of approver user-IDs for the given flow.
+     */
+    public function buildApproverChain(ApprovalFlow $flow): array
+    {
+        $steps = $flow->steps ?? [];
+
+        usort($steps, fn($a, $b) => ($a['order'] ?? 0) <=> ($b['order'] ?? 0));
+
+        return array_map(fn($s) => (int) $s['approver_id'], $steps);
+    }
+
+    /**
+     * Determine whether the expense can skip approval entirely.
+     */
+    public function canAutoApprove(Expense $expense): bool
+    {
+        $flow = $this->resolveFlow($expense);
+
+        if ($flow === null) {
+            return false;
+        }
+
+        return (bool) ($flow->auto_approve ?? false);
+    }
+
+    /**
+     * Return the next approver in the chain, or null if fully approved.
+     */
+    public function nextApprover(Expense $expense): ?int
+    {
+        $flow = $this->resolveFlow($expense);
+
+        if ($flow === null) {
+            return null;
+        }
+
+        $chain    = $this->buildApproverChain($flow);
+        $approved = $expense->approvalRecords()
+            ->where('action', 'approved')
+            ->pluck('approver_id')
+            ->toArray();
+
+        foreach ($chain as $approverId) {
+            if (!in_array($approverId, $approved, true)) {
+                return $approverId;
+            }
+        }
+
+        return null;
+    }
+}

--- a/expense-management/backend/tests/Unit/ApprovalPolicyServiceTest.php
+++ b/expense-management/backend/tests/Unit/ApprovalPolicyServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\ApprovalFlow;
+use App\Models\Expense;
+use App\Services\ApprovalPolicyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApprovalPolicyServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ApprovalPolicyService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ApprovalPolicyService();
+    }
+
+    public function test_resolves_flow_by_amount_range(): void
+    {
+        $flow = ApprovalFlow::factory()->create([
+            'tenant_id'  => 1,
+            'min_amount' => 10000,
+            'max_amount' => 100000,
+            'is_active'  => true,
+            'priority'   => 1,
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'total_amount' => 50000]);
+
+        $resolved = $this->service->resolveFlow($expense);
+        $this->assertNotNull($resolved);
+        $this->assertEquals($flow->id, $resolved->id);
+    }
+
+    public function test_returns_null_when_no_matching_flow(): void
+    {
+        ApprovalFlow::factory()->create([
+            'tenant_id'  => 1,
+            'min_amount' => 100000,
+            'max_amount' => null,
+            'is_active'  => true,
+            'priority'   => 1,
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'total_amount' => 5000]);
+
+        $this->assertNull($this->service->resolveFlow($expense));
+    }
+
+    public function test_build_approver_chain_sorts_by_order(): void
+    {
+        $flow = ApprovalFlow::factory()->make([
+            'steps' => [
+                ['order' => 2, 'approver_id' => 20],
+                ['order' => 1, 'approver_id' => 10],
+                ['order' => 3, 'approver_id' => 30],
+            ],
+        ]);
+
+        $chain = $this->service->buildApproverChain($flow);
+        $this->assertEquals([10, 20, 30], $chain);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ApprovalPolicyService` — resolves the correct approval flow for an expense based on amount range, department, and category with priority ordering
- `resolveFlow()` — filters active flows by amount range + optional dept/category, returns highest-priority match
- `buildApproverChain()` — sorts flow steps by `order` and returns ordered approver IDs
- `canAutoApprove()` — checks if the matched flow has `auto_approve` flag
- `nextApprover()` — returns the first unapproved approver in the chain (or null if fully approved)
- Unit tests: flow resolution by amount range, null when no match, chain sort order

## Changes

- `expense-management/backend/app/Services/ApprovalPolicyService.php`
- `expense-management/backend/tests/Unit/ApprovalPolicyServiceTest.php`

## Test plan

- [ ] `php artisan test --filter ApprovalPolicyServiceTest` — all 3 unit tests pass
- [ ] `nextApprover()` returns null after all chain members have approved
- [ ] Lower `priority` value wins when multiple flows match the same amount

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_