### PR TITLE
feat: Add async PDF export job with Blade template and S3 presigned URL

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/PdfExportController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/PdfExportController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\GenerateExpensePdf;
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class PdfExportController extends Controller
+{
+    public function expense(int $id): JsonResponse
+    {
+        $expense = Expense::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        GenerateExpensePdf::dispatch($expense->id, Auth::id());
+
+        return response()->json([
+            'message' => 'PDFの生成を開始しました。完了次第通知します。',
+        ], 202);
+    }
+}

--- a/expense-management/backend/app/Jobs/GenerateExpensePdf.php
+++ b/expense-management/backend/app/Jobs/GenerateExpensePdf.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Expense;
+use App\Models\User;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+
+class GenerateExpensePdf implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries   = 2;
+    public int $timeout = 120;
+
+    public function __construct(
+        private readonly int $expenseId,
+        private readonly int $requesterId,
+    ) {
+        $this->onQueue('reports');
+    }
+
+    public function handle(): void
+    {
+        $expense = Expense::with([
+            'items',
+            'receipts',
+            'applicant',
+            'approvalRecords.approver',
+            'category',
+        ])->findOrFail($this->expenseId);
+
+        $pdf = Pdf::loadView('pdf.expense', ['expense' => $expense])
+            ->setPaper('a4', 'portrait')
+            ->setOption('defaultFont', 'sans-serif')
+            ->setOption('isRemoteEnabled', false);
+
+        $filename = sprintf(
+            'exports/expense-%s-%s.pdf',
+            $expense->expense_number,
+            now()->format('YmdHis'),
+        );
+
+        Storage::disk('s3')->put($filename, $pdf->output(), 'private');
+
+        $url = Storage::disk('s3')->temporaryUrl($filename, now()->addMinutes(30));
+
+        $requester = User::find($this->requesterId);
+        if ($requester) {
+            $requester->notify(new \App\Notifications\ExpensePdfReady(
+                $expense->expense_number,
+                $url,
+            ));
+        }
+    }
+}

--- a/expense-management/backend/resources/views/pdf/expense.blade.php
+++ b/expense-management/backend/resources/views/pdf/expense.blade.php
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<style>
+  body { font-family: sans-serif; font-size: 12px; color: #111; margin: 0; padding: 24px; }
+  h1 { font-size: 18px; margin-bottom: 4px; }
+  .meta { color: #555; font-size: 11px; margin-bottom: 20px; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+  th { background: #4f46e5; color: #fff; padding: 6px 8px; text-align: left; font-size: 11px; }
+  td { padding: 6px 8px; border-bottom: 1px solid #e5e7eb; font-size: 11px; }
+  .right { text-align: right; }
+  .total { font-weight: bold; font-size: 13px; }
+  .section { margin-bottom: 20px; }
+  .section-title { font-size: 13px; font-weight: bold; border-bottom: 2px solid #4f46e5; margin-bottom: 8px; padding-bottom: 4px; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 9999px; font-size: 10px; font-weight: bold; }
+  .badge-approved { background: #d1fae5; color: #065f46; }
+  .badge-rejected { background: #fee2e2; color: #991b1b; }
+  .badge-pending { background: #fef3c7; color: #92400e; }
+</style>
+</head>
+<body>
+<h1>{{ $expense->title }}</h1>
+<div class="meta">
+  第号: {{ $expense->expense_number }} &nbsp;|
+  申請者: {{ $expense->applicant?->name }} &nbsp;|
+  申請日: {{ $expense->created_at?->format('Y/m/d') }} &nbsp;|
+  ステータス:
+  <span class="badge badge-{{ str_replace(['submitted','approved','rejected','draft','paid'], ['pending','approved','rejected','pending','approved'], $expense->status) }}">
+    {{ $expense->status }}
+  </span>
+</div>
+
+<div class="section">
+  <div class="section-title">明細</div>
+  <table>
+    <thead><tr><th>販売店 / 内容</th><th>カテゴリ</th><th>日付</th><th class="right">金額</th></tr></thead>
+    <tbody>
+      @foreach ($expense->items as $item)
+      <tr>
+        <td>{{ $item->description }}</td>
+        <td>{{ $item->category?->name ?? '-' }}</td>
+        <td>{{ $item->incurred_at?->format('Y/m/d') }}</td>
+        <td class="right">&yen;{{ number_format($item->amount) }}</td>
+      </tr>
+      @endforeach
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="3" class="right total">合計</td>
+        <td class="right total">&yen;{{ number_format($expense->total_amount) }}</td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+
+@if ($expense->approvalRecords->isNotEmpty())
+<div class="section">
+  <div class="section-title">承認履歴</div>
+  <table>
+    <thead><tr><th>承認者</th><th>アクション</th><th>日時</th><th>コメント</th></tr></thead>
+    <tbody>
+      @foreach ($expense->approvalRecords as $record)
+      <tr>
+        <td>{{ $record->approver?->name }}</td>
+        <td>{{ $record->action }}</td>
+        <td>{{ $record->created_at?->format('Y/m/d H:i') }}</td>
+        <td>{{ $record->comment ?? '-' }}</td>
+      </tr>
+      @endforeach
+    </tbody>
+  </table>
+</div>
+@endif
+
+<div class="meta" style="margin-top:40px; border-top:1px solid #e5e7eb; padding-top:8px;">
+  出力日時: {{ now()->format('Y/m/d H:i:s') }}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `GenerateExpensePdf` queued job (`reports` queue) — renders expense detail via Dompdf + Blade, uploads to S3 private path, notifies requester with a 30-minute presigned URL
- Blade template (`pdf/expense.blade.php`) — A4 portrait, Japanese labels, line-item table with totals, approval history, generation timestamp
- `PdfExportController` — `POST /api/v1/expenses/:id/export/pdf` dispatches the job and returns 202 immediately (async)

## Changes

- `expense-management/backend/app/Jobs/GenerateExpensePdf.php`
- `expense-management/backend/resources/views/pdf/expense.blade.php`
- `expense-management/backend/app/Http/Controllers/Api/V1/PdfExportController.php`

## Test plan

- [ ] `POST /expenses/:id/export/pdf` returns 202 without blocking
- [ ] PDF is uploaded to `exports/expense-{number}-{timestamp}.pdf` in S3
- [ ] Presigned URL expires after 30 minutes
- [ ] Approval history section is hidden when no records exist
- [ ] Cross-tenant — cannot export another tenant's expense

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_