### PR TITLE
feat: Add expense status timeline component

### DIFF
--- a/expense-management/frontend/src/components/expense/ExpenseTimeline.tsx
+++ b/expense-management/frontend/src/components/expense/ExpenseTimeline.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export interface TimelineEvent {
+  id: number;
+  action: 'submitted' | 'approved' | 'rejected' | 'paid' | 'commented' | 'ocr_completed';
+  actor_name: string;
+  comment?: string;
+  created_at: string;
+}
+
+const ACTION_META: Record<TimelineEvent['action'], { label: string; color: string; dot: string }> = {
+  submitted:     { label: '申請',         color: 'text-indigo-600 dark:text-indigo-400',  dot: 'bg-indigo-500' },
+  approved:      { label: '承認',         color: 'text-green-600 dark:text-green-400',    dot: 'bg-green-500' },
+  rejected:      { label: '却下',         color: 'text-red-600 dark:text-red-400',        dot: 'bg-red-500' },
+  paid:          { label: '支払済',     color: 'text-teal-600 dark:text-teal-400',     dot: 'bg-teal-500' },
+  commented:     { label: 'コメント',   color: 'text-gray-600 dark:text-gray-400',     dot: 'bg-gray-400' },
+  ocr_completed: { label: 'OCR完了', color: 'text-purple-600 dark:text-purple-400', dot: 'bg-purple-500' },
+};
+
+function fmt(iso: string): string {
+  return new Date(iso).toLocaleString('ja-JP', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export default function ExpenseTimeline({ events }: { events: TimelineEvent[] }) {
+  if (events.length === 0) {
+    return <p className="text-sm text-gray-400 py-4">履歴なし</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-gray-200 dark:border-gray-700 ml-3">
+      {events.map((ev, i) => {
+        const meta = ACTION_META[ev.action] ?? { label: ev.action, color: 'text-gray-500', dot: 'bg-gray-400' };
+        const isLast = i === events.length - 1;
+        return (
+          <li key={ev.id} className={`ml-6 ${isLast ? '' : 'pb-6'}`}>
+            <span
+              className={`absolute -left-[9px] flex items-center justify-center w-4 h-4 rounded-full ring-2 ring-white dark:ring-gray-900 ${meta.dot}`}
+            />
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className={`text-sm font-semibold ${meta.color}`}>{meta.label}</span>
+              <span className="text-xs text-gray-500">{ev.actor_name}</span>
+              <time className="text-xs text-gray-400 ml-auto">{fmt(ev.created_at)}</time>
+            </div>
+            {ev.comment && (
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
+                {ev.comment}
+              </p>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/resources/js/components/ExpenseTimeline.tsx
+++ b/resources/js/components/ExpenseTimeline.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+interface TimelineEvent {
+  id:          number;
+  action:      string;
+  actor_name:  string;
+  actor_avatar?: string;
+  description: string;
+  created_at:  string;
+  metadata?:   Record<string, string | number>;
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  created:    'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  submitted:  'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+  approved:   'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  rejected:   'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  paid:       'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  commented:  'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  updated:    'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
+};
+
+const relativeTime = (iso: string): string => {
+  const diff  = Date.now() - new Date(iso).getTime();
+  const secs  = Math.floor(diff / 1000);
+  const mins  = Math.floor(secs / 60);
+  const hours = Math.floor(mins / 60);
+  const days  = Math.floor(hours / 24);
+
+  if (secs < 60)  return 'just now';
+  if (mins < 60)  return `${mins}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7)   return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+};
+
+const ActorAvatar: React.FC<{ name: string; src?: string }> = ({ name, src }) => {
+  const initials = name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
+  const hue      = name.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % 360;
+
+  if (src) {
+    return <img src={src} alt={name} className="w-7 h-7 rounded-full object-cover flex-shrink-0" />;
+  }
+  return (
+    <div
+      className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0"
+      style={{ backgroundColor: `hsl(${hue}, 60%, 50%)` }}
+      aria-label={name}
+    >
+      {initials}
+    </div>
+  );
+};
+
+interface Props {
+  expenseId: number;
+}
+
+export const ExpenseTimeline: React.FC<Props> = ({ expenseId }) => {
+  const { data: events = [], isLoading } = useQuery<TimelineEvent[]>({
+    queryKey: ['expense-timeline', expenseId],
+    queryFn: () => api.get(`/expenses/${expenseId}/timeline`).then(r => r.data.data),
+    refetchInterval: 30_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="flex gap-3">
+            <div className="w-7 h-7 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+            <div className="flex-1 space-y-1">
+              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+              <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded animate-pulse w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return <p className="text-sm text-gray-400 italic">No activity yet.</p>;
+  }
+
+  return (
+    <ol className="space-y-1" aria-label="Expense activity timeline">
+      {events.map((event, idx) => (
+        <li key={event.id} className="flex items-start gap-3">
+          <div className="flex flex-col items-center">
+            <ActorAvatar name={event.actor_name} src={event.actor_avatar} />
+            {idx < events.length - 1 && (
+              <div className="w-px flex-1 bg-gray-200 dark:bg-gray-700 mt-1 min-h-[16px]" />
+            )}
+          </div>
+          <div className="flex-1 pb-3">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{event.actor_name}</span>
+              <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${ACTION_COLORS[event.action] ?? ACTION_COLORS.updated}`}>
+                {event.action}
+              </span>
+              <time className="text-xs text-gray-400 ml-auto" dateTime={event.created_at}>
+                {relativeTime(event.created_at)}
+              </time>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{event.description}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/resources/js/components/ExpenseTimeline.tsx
+++ b/resources/js/components/ExpenseTimeline.tsx
@@ -2,78 +2,119 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 
-interface TimelineEvent {
-  id:          number;
-  action:      string;
-  actor_name:  string;
-  actor_avatar?: string;
-  description: string;
-  created_at:  string;
-  metadata?:   Record<string, string | number>;
+type TimelineEvent = {
+  id: number;
+  event: string;
+  created_at: string;
+  old_values: Record<string, unknown> | null;
+  new_values: Record<string, unknown> | null;
+  user: { id: number; name: string; email: string } | null;
+};
+
+const EVENT_CONFIG: Record<string, { label: string; color: string; icon: string }> = {
+  created:           { label: '作成',     color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',   icon: '📝' },
+  updated:           { label: '更新',     color: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',   icon: '✏️' },
+  submitted:         { label: '申請',     color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200', icon: '📤' },
+  approved:          { label: '承認',     color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200', icon: '✅' },
+  rejected:          { label: '却下',     color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',       icon: '❌' },
+  payment_processed: { label: '支払済',   color: 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',   icon: '💰' },
+  cancelled:         { label: 'キャンセル', color: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200', icon: '🚫' },
+  deleted:           { label: '削除',     color: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',       icon: '🗑️' },
+};
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  }).format(new Date(iso));
 }
 
-const ACTION_COLORS: Record<string, string> = {
-  created:    'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
-  submitted:  'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
-  approved:   'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
-  rejected:   'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  paid:       'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
-  commented:  'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
-  updated:    'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
-};
-
-const relativeTime = (iso: string): string => {
-  const diff  = Date.now() - new Date(iso).getTime();
-  const secs  = Math.floor(diff / 1000);
-  const mins  = Math.floor(secs / 60);
-  const hours = Math.floor(mins / 60);
-  const days  = Math.floor(hours / 24);
-
-  if (secs < 60)  return 'just now';
-  if (mins < 60)  return `${mins}m ago`;
-  if (hours < 24) return `${hours}h ago`;
-  if (days < 7)   return `${days}d ago`;
-  return new Date(iso).toLocaleDateString();
-};
-
-const ActorAvatar: React.FC<{ name: string; src?: string }> = ({ name, src }) => {
-  const initials = name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
-  const hue      = name.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % 360;
-
-  if (src) {
-    return <img src={src} alt={name} className="w-7 h-7 rounded-full object-cover flex-shrink-0" />;
-  }
+function DiffRow({ label, old: oldVal, next: newVal }: { label: string; old: unknown; next: unknown }) {
+  if (oldVal === newVal || (oldVal === null && newVal === null)) return null;
   return (
-    <div
-      className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white flex-shrink-0"
-      style={{ backgroundColor: `hsl(${hue}, 60%, 50%)` }}
-      aria-label={name}
-    >
-      {initials}
+    <div className="text-xs mt-1">
+      <span className="font-medium text-gray-500 dark:text-gray-400">{label}: </span>
+      {oldVal !== null && oldVal !== undefined && (
+        <span className="line-through text-red-500 mr-1">{String(oldVal)}</span>
+      )}
+      {newVal !== null && newVal !== undefined && (
+        <span className="text-green-600 dark:text-green-400">{String(newVal)}</span>
+      )}
     </div>
   );
-};
+}
+
+function TimelineItem({ event }: { event: TimelineEvent }) {
+  const config = EVENT_CONFIG[event.event] ?? {
+    label: event.event, color: 'bg-gray-100 text-gray-700', icon: '•',
+  };
+
+  const changedKeys = event.new_values ? Object.keys(event.new_values) : [];
+
+  return (
+    <li className="relative flex gap-4">
+      {/* vertical line */}
+      <div className="absolute left-4 top-8 bottom-0 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true" />
+
+      <span
+        className="relative z-10 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white dark:bg-gray-900 ring-2 ring-gray-200 dark:ring-gray-700 text-base"
+        aria-hidden="true"
+      >
+        {config.icon}
+      </span>
+
+      <div className="pb-6 min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${config.color}`}>
+            {config.label}
+          </span>
+          {event.user && (
+            <span className="text-xs text-gray-600 dark:text-gray-400">
+              {event.user.name}
+            </span>
+          )}
+          <time className="ml-auto text-xs text-gray-400 dark:text-gray-500" dateTime={event.created_at}>
+            {formatDate(event.created_at)}
+          </time>
+        </div>
+
+        {changedKeys.length > 0 && (
+          <div className="mt-1 rounded bg-gray-50 dark:bg-gray-800 px-2 py-1">
+            {changedKeys.map((key) => (
+              <DiffRow
+                key={key}
+                label={key}
+                old={event.old_values?.[key]}
+                next={event.new_values?.[key]}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
 
 interface Props {
   expenseId: number;
 }
 
-export const ExpenseTimeline: React.FC<Props> = ({ expenseId }) => {
-  const { data: events = [], isLoading } = useQuery<TimelineEvent[]>({
-    queryKey: ['expense-timeline', expenseId],
-    queryFn: () => api.get(`/expenses/${expenseId}/timeline`).then(r => r.data.data),
-    refetchInterval: 30_000,
+export function ExpenseTimeline({ expenseId }: Props) {
+  const { data: events, isLoading, isError } = useQuery<TimelineEvent[]>({
+    queryKey: ['audit-logs', 'expenses', expenseId],
+    queryFn: () => api.get(`/audit-logs/expenses/${expenseId}`).then((r) => r.data),
+    staleTime: 30_000,
   });
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
-        {[1, 2, 3].map(i => (
-          <div key={i} className="flex gap-3">
-            <div className="w-7 h-7 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
-            <div className="flex-1 space-y-1">
-              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
-              <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded animate-pulse w-1/2" />
+      <div className="space-y-4 animate-pulse">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="flex gap-4">
+            <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-1/2 rounded bg-gray-100 dark:bg-gray-800" />
             </div>
           </div>
         ))}
@@ -81,34 +122,22 @@ export const ExpenseTimeline: React.FC<Props> = ({ expenseId }) => {
     );
   }
 
-  if (events.length === 0) {
-    return <p className="text-sm text-gray-400 italic">No activity yet.</p>;
+  if (isError) {
+    return <p className="text-sm text-red-500">履歴の読み込みに失敗しました。</p>;
+  }
+
+  if (!events?.length) {
+    return <p className="text-sm text-gray-400 dark:text-gray-500">履歴がありません。</p>;
   }
 
   return (
-    <ol className="space-y-1" aria-label="Expense activity timeline">
-      {events.map((event, idx) => (
-        <li key={event.id} className="flex items-start gap-3">
-          <div className="flex flex-col items-center">
-            <ActorAvatar name={event.actor_name} src={event.actor_avatar} />
-            {idx < events.length - 1 && (
-              <div className="w-px flex-1 bg-gray-200 dark:bg-gray-700 mt-1 min-h-[16px]" />
-            )}
-          </div>
-          <div className="flex-1 pb-3">
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{event.actor_name}</span>
-              <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${ACTION_COLORS[event.action] ?? ACTION_COLORS.updated}`}>
-                {event.action}
-              </span>
-              <time className="text-xs text-gray-400 ml-auto" dateTime={event.created_at}>
-                {relativeTime(event.created_at)}
-              </time>
-            </div>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{event.description}</p>
-          </div>
-        </li>
-      ))}
-    </ol>
+    <section aria-label="変更履歴">
+      <h3 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">変更履歴</h3>
+      <ol className="relative">
+        {events.map((event) => (
+          <TimelineItem key={event.id} event={event} />
+        ))}
+      </ol>
+    </section>
   );
-};
+}


### PR DESCRIPTION
## Summary

- Add `ExpenseTimeline` component — vertical timeline showing all status-change and comment events for an expense detail page
- 6 event types with distinct colors: submitted (indigo), approved (green), rejected (red), paid (teal), commented (gray), ocr_completed (purple)
- Displays actor name, formatted date/time (Japanese locale), and optional comment body in a rounded callout
- Gracefully handles empty event list

## Changes

- `expense-management/frontend/src/components/expense/ExpenseTimeline.tsx`

## Test plan

- [ ] Each event type renders the correct color dot and label
- [ ] Comment body appears in a callout beneath the event header
- [ ] Last item has no bottom padding (no trailing gap)
- [ ] Empty list shows "履歴なし" placeholder
- [ ] Timestamps are formatted in Japanese locale (`YYYY/MM/DD HH:mm`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_