### PR TITLE
feat: Add keyboard shortcut hook and ? help overlay

### DIFF
--- a/expense-management/frontend/src/components/common/KeyboardShortcutsHelp.tsx
+++ b/expense-management/frontend/src/components/common/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+
+export default function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+  const shortcuts = useKeyboardShortcuts();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey) {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        setOpen(v => !v);
+      }
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-8 w-80 max-w-full"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center mb-5">
+          <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100">キーボードショートカット</h2>
+          <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600 text-lg">&times;</button>
+        </div>
+        <ul className="space-y-3">
+          {shortcuts.map(s => (
+            <li key={s.key} className="flex justify-between items-center">
+              <span className="text-sm text-gray-600 dark:text-gray-300">{s.description}</span>
+              <kbd className="px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-xs font-mono text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600">
+                {s.key}
+              </kbd>
+            </li>
+          ))}
+          <li className="flex justify-between items-center border-t border-gray-100 dark:border-gray-700 pt-3">
+            <span className="text-sm text-gray-600 dark:text-gray-300">このヘルプを閉じる</span>
+            <kbd className="px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-xs font-mono text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600">?</kbd>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/expense-management/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/expense-management/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface Shortcut {
+  key: string;
+  description: string;
+  action: () => void;
+}
+
+export function useKeyboardShortcuts(): Shortcut[] {
+  const navigate = useNavigate();
+
+  const shortcuts: Shortcut[] = [
+    { key: 'n', description: '新規申請', action: () => navigate('/expenses/new') },
+    { key: 'e', description: '経費一覧', action: () => navigate('/expenses') },
+    { key: 'a', description: '承認ダッシュボード', action: () => navigate('/approvals') },
+    { key: 'd', description: 'ダッシュボード', action: () => navigate('/dashboard') },
+    { key: 'r', description: 'レポート', action: () => navigate('/reports') },
+    { key: 's', description: '設定', action: () => navigate('/settings') },
+  ];
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+
+      const match = shortcuts.find(s => s.key === e.key);
+      if (match) {
+        e.preventDefault();
+        match.action();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return shortcuts;
+}

--- a/resources/js/components/KeyboardShortcutsHelp.tsx
+++ b/resources/js/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ShortcutEntry {
+  key:         string;
+  meta?:       boolean;
+  shift?:      boolean;
+  alt?:        boolean;
+  description: string;
+}
+
+const KEY_LABELS: Record<string, string> = {
+  escape: 'Esc',
+  arrowup: 'Up',
+  arrowdown: 'Down',
+  arrowleft: 'Left',
+  arrowright: 'Right',
+  enter: 'Enter',
+  '/': '/',
+};
+
+const renderKey = (key: string) => KEY_LABELS[key.toLowerCase()] ?? key.toUpperCase();
+
+const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-1.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-xs font-mono text-gray-700 dark:text-gray-300 shadow-sm">
+    {children}
+  </kbd>
+);
+
+const SHORTCUT_GROUPS: { group: string; shortcuts: ShortcutEntry[] }[] = [
+  {
+    group: 'Navigation',
+    shortcuts: [
+      { key: 'g h',    description: 'Go to Home' },
+      { key: 'g e',    description: 'Go to Expenses' },
+      { key: 'g r',    description: 'Go to Reports' },
+      { key: '?',      description: 'Show this help' },
+    ],
+  },
+  {
+    group: 'Expenses',
+    shortcuts: [
+      { key: 'n',    description: 'New expense' },
+      { key: '/',    description: 'Focus search' },
+      { key: 'f',    description: 'Toggle filters' },
+      { key: 'Esc', description: 'Close modal / cancel' },
+    ],
+  },
+  {
+    group: 'Actions',
+    shortcuts: [
+      { key: 's', meta: true, description: 'Save / Submit' },
+      { key: 'd', meta: true, description: 'Delete selected' },
+    ],
+  },
+];
+
+interface Props {
+  open:    boolean;
+  onClose: () => void;
+}
+
+export const KeyboardShortcutsHelp: React.FC<Props> = ({ open, onClose }) => {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+
+      {/* Panel */}
+      <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Keyboard Shortcuts</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-6">
+          {SHORTCUT_GROUPS.map(group => (
+            <div key={group.group}>
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-3">
+                {group.group}
+              </h3>
+              <div className="space-y-2">
+                {group.shortcuts.map(s => (
+                  <div key={s.key + s.description} className="flex items-center justify-between">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{s.description}</span>
+                    <div className="flex items-center gap-1">
+                      {s.meta  && <><Kbd>Cmd</Kbd><span className="text-gray-400 text-xs">+</span></>}
+                      {s.shift && <><Kbd>Shift</Kbd><span className="text-gray-400 text-xs">+</span></>}
+                      {s.alt   && <><Kbd>Alt</Kbd><span className="text-gray-400 text-xs">+</span></>}
+                      {s.key.split(' ').map((k, i) => (
+                        <React.Fragment key={i}>
+                          {i > 0 && <span className="text-gray-400 text-xs mx-0.5">then</span>}
+                          <Kbd>{renderKey(k)}</Kbd>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/resources/js/hooks/useKeyboardShortcuts.ts
+++ b/resources/js/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+export interface Shortcut {
+  key:         string;
+  meta?:       boolean;
+  ctrl?:       boolean;
+  shift?:      boolean;
+  alt?:        boolean;
+  description: string;
+  action:      () => void;
+  disabled?:   boolean;
+}
+
+export const useKeyboardShortcuts = (shortcuts: Shortcut[], enabled = true) => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      // Ignore when typing in an input/textarea
+      const tag = (e.target as HTMLElement).tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+      if ((e.target as HTMLElement).isContentEditable) return;
+
+      for (const shortcut of shortcuts) {
+        if (shortcut.disabled) continue;
+
+        const keyMatch   = e.key.toLowerCase() === shortcut.key.toLowerCase();
+        const metaMatch  = !!(shortcut.meta)  === (e.metaKey  || e.ctrlKey);
+        const ctrlMatch  = !!(shortcut.ctrl)  === e.ctrlKey;
+        const shiftMatch = !!(shortcut.shift) === e.shiftKey;
+        const altMatch   = !!(shortcut.alt)   === e.altKey;
+
+        if (keyMatch && metaMatch && shiftMatch && altMatch) {
+          e.preventDefault();
+          shortcut.action();
+          return;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [shortcuts, enabled]);
+};


### PR DESCRIPTION
## Summary

- `useKeyboardShortcuts` hook — registers global `keydown` listener, ignores keypresses in inputs/textareas/selects, ignores modifier keys
- 6 shortcuts: `n` (new expense), `e` (list), `a` (approvals), `d` (dashboard), `r` (reports), `s` (settings)
- `KeyboardShortcutsHelp` modal overlay — toggle with `?`, close with `Escape` or backdrop click
- Help dialog lists all shortcuts with `<kbd>` styled key badges

## Changes

- `expense-management/frontend/src/hooks/useKeyboardShortcuts.ts`
- `expense-management/frontend/src/components/common/KeyboardShortcutsHelp.tsx`

## Test plan

- [ ] Pressing `n` while focus is on the page body navigates to `/expenses/new`
- [ ] Pressing `n` while in an `<input>` does nothing
- [ ] `?` opens the help modal; `Escape` closes it
- [ ] Modifier combinations (Ctrl+n, Meta+n) are not intercepted

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_