### PR TITLE
feat: Add TOTP-based two-factor authentication (setup/enable/disable/verify)

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/TwoFactorController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/TwoFactorController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use PragmaRX\Google2FA\Google2FA;
+
+class TwoFactorController extends Controller
+{
+    public function __construct(private readonly Google2FA $google2fa)
+    {
+    }
+
+    /** Generate and return a new TOTP secret + provisioning URI for QR code */
+    public function setup(): JsonResponse
+    {
+        $user   = Auth::user();
+        $secret = $this->google2fa->generateSecretKey(32);
+
+        $user->update(['two_factor_secret_pending' => encrypt($secret)]);
+
+        $uri = $this->google2fa->getQRCodeUrl(
+            config('app.name'),
+            $user->email,
+            $secret,
+        );
+
+        return response()->json([
+            'secret'           => $secret,
+            'provisioning_uri' => $uri,
+        ]);
+    }
+
+    /** Verify a TOTP code and activate 2FA on the user account */
+    public function enable(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'code'     => 'required|string|size:6',
+            'password' => 'required|string',
+        ]);
+
+        $user = Auth::user();
+
+        if (!Hash::check($data['password'], $user->password)) {
+            return response()->json(['message' => 'Password confirmation failed.'], 403);
+        }
+
+        $pending = decrypt($user->two_factor_secret_pending ?? '');
+
+        if (!$this->google2fa->verifyKey($pending, $data['code'])) {
+            return response()->json(['message' => 'Invalid TOTP code.'], 422);
+        }
+
+        $recoveryCodes = $this->generateRecoveryCodes();
+
+        $user->update([
+            'two_factor_secret'          => encrypt($pending),
+            'two_factor_secret_pending'  => null,
+            'two_factor_recovery_codes'  => encrypt(json_encode($recoveryCodes)),
+            'two_factor_enabled_at'      => now(),
+        ]);
+
+        return response()->json([
+            'message'        => 'Two-factor authentication enabled.',
+            'recovery_codes' => $recoveryCodes,
+        ]);
+    }
+
+    /** Disable 2FA after password confirmation */
+    public function disable(Request $request): JsonResponse
+    {
+        $data = $request->validate(['password' => 'required|string']);
+        $user = Auth::user();
+
+        if (!Hash::check($data['password'], $user->password)) {
+            return response()->json(['message' => 'Password confirmation failed.'], 403);
+        }
+
+        $user->update([
+            'two_factor_secret'         => null,
+            'two_factor_recovery_codes' => null,
+            'two_factor_enabled_at'     => null,
+        ]);
+
+        return response()->json(['message' => 'Two-factor authentication disabled.']);
+    }
+
+    /** Verify a TOTP code during login challenge */
+    public function verify(Request $request): JsonResponse
+    {
+        $data = $request->validate(['code' => 'required|string']);
+        $user = Auth::user();
+
+        if (!$user->two_factor_secret) {
+            return response()->json(['message' => '2FA is not enabled on this account.'], 422);
+        }
+
+        $secret = decrypt($user->two_factor_secret);
+
+        // Check TOTP code
+        if ($this->google2fa->verifyKey($secret, $data['code'])) {
+            session()->put('two_factor_verified', true);
+            return response()->json(['message' => '2FA verified.']);
+        }
+
+        // Check recovery codes
+        $codes = json_decode(decrypt($user->two_factor_recovery_codes ?? '[]'), true);
+        $index = array_search($data['code'], $codes, true);
+
+        if ($index !== false) {
+            unset($codes[$index]);
+            $user->update(['two_factor_recovery_codes' => encrypt(json_encode(array_values($codes)))]);
+            session()->put('two_factor_verified', true);
+            return response()->json(['message' => 'Recovery code accepted. Remaining codes: ' . count($codes)]);
+        }
+
+        return response()->json(['message' => 'Invalid code.'], 422);
+    }
+
+    private function generateRecoveryCodes(int $count = 8): array
+    {
+        return array_map(
+            fn() => sprintf('%s-%s', bin2hex(random_bytes(4)), bin2hex(random_bytes(4))),
+            array_fill(0, $count, null)
+        );
+    }
+}

--- a/expense-management/backend/database/migrations/2024_01_15_000012_add_two_factor_columns_to_users.php
+++ b/expense-management/backend/database/migrations/2024_01_15_000012_add_two_factor_columns_to_users.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('two_factor_secret')->nullable()->after('password');
+            $table->text('two_factor_secret_pending')->nullable()->after('two_factor_secret');
+            $table->text('two_factor_recovery_codes')->nullable()->after('two_factor_secret_pending');
+            $table->timestamp('two_factor_enabled_at')->nullable()->after('two_factor_recovery_codes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'two_factor_secret',
+                'two_factor_secret_pending',
+                'two_factor_recovery_codes',
+                'two_factor_enabled_at',
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- `TwoFactorController` with four endpoints: `setup`, `enable`, `disable`, `verify`
- `setup` — generates 32-char TOTP secret, stores encrypted pending secret, returns provisioning URI for QR code
- `enable` — verifies TOTP code + password confirmation, activates 2FA, returns 8 one-time recovery codes
- `disable` — requires password confirmation, clears all 2FA columns
- `verify` — accepts TOTP code or recovery code; burns used recovery code
- Migration adds `two_factor_secret`, `two_factor_secret_pending`, `two_factor_recovery_codes`, `two_factor_enabled_at` columns to `users`

## Changes

- `expense-management/backend/app/Http/Controllers/Api/V1/TwoFactorController.php`
- `expense-management/backend/database/migrations/2024_01_15_000012_add_two_factor_columns_to_users.php`

## Test plan

- [ ] `setup` returns a valid `otpauth://` URI
- [ ] `enable` with correct TOTP code activates 2FA and returns 8 recovery codes
- [ ] `enable` with wrong code returns 422
- [ ] `verify` with recovery code burns the code (cannot reuse)
- [ ] `disable` without password returns 403

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_