### PR TITLE
feat: Add MySQL FULLTEXT index and global search endpoint

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/SearchController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/SearchController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class SearchController extends Controller
+{
+    private const MAX_RESULTS = 50;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $query = trim($request->string('q'));
+
+        if (mb_strlen($query) < 2) {
+            return response()->json(['data' => [], 'meta' => ['total' => 0]]);
+        }
+
+        $tenantId = Auth::user()->tenant_id;
+
+        // Boolean mode FULLTEXT search with automatic AND for multiple words
+        $boolQuery = collect(preg_split('/\s+/', $query))
+            ->filter()
+            ->map(fn($w) => '+' . preg_replace('/[+\-><()~*"@]+/', '', $w) . '*')
+            ->implode(' ');
+
+        $expenses = Expense::where('tenant_id', $tenantId)
+            ->where(function ($q) use ($boolQuery, $query) {
+                $q->whereRaw(
+                    'MATCH(title, description, expense_number) AGAINST(? IN BOOLEAN MODE)',
+                    [$boolQuery]
+                )->orWhereHas('items', fn($iq) =>
+                    $iq->whereRaw(
+                        'MATCH(description, vendor_name) AGAINST(? IN BOOLEAN MODE)',
+                        [$boolQuery]
+                    )
+                );
+            })
+            ->select([
+                'id', 'expense_number', 'title', 'status', 'total_amount',
+                'applicant_id', 'created_at',
+                DB::raw('MATCH(title, description, expense_number) AGAINST(? IN BOOLEAN MODE) AS relevance'),
+            ])
+            ->addBinding($boolQuery, 'select')
+            ->with('applicant:id,name')
+            ->orderByDesc('relevance')
+            ->limit(self::MAX_RESULTS)
+            ->get();
+
+        return response()->json([
+            'data' => $expenses->map(fn($e) => [
+                'id'             => $e->id,
+                'expense_number' => $e->expense_number,
+                'title'          => $e->title,
+                'status'         => $e->status,
+                'total_amount'   => $e->total_amount,
+                'applicant_name' => $e->applicant?->name,
+                'created_at'     => $e->created_at->toIso8601String(),
+            ]),
+            'meta' => [
+                'total' => $expenses->count(),
+                'query' => $query,
+            ],
+        ]);
+    }
+}

--- a/expense-management/backend/database/migrations/2024_01_15_000013_add_fulltext_index_to_expenses.php
+++ b/expense-management/backend/database/migrations/2024_01_15_000013_add_fulltext_index_to_expenses.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add fulltext index on expenses table (MySQL 5.6+ / Aurora MySQL 5.6+)
+        // Covers title, description, and expense_number for keyword search
+        DB::statement(
+            'ALTER TABLE expenses ADD FULLTEXT INDEX ft_expenses_search (title, description, expense_number)'
+        );
+
+        // Add fulltext index on expense_items for vendor/description search
+        DB::statement(
+            'ALTER TABLE expense_items ADD FULLTEXT INDEX ft_items_search (description, vendor_name)'
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE expenses DROP INDEX ft_expenses_search');
+        DB::statement('ALTER TABLE expense_items DROP INDEX ft_items_search');
+    }
+};


### PR DESCRIPTION
## Summary

- Migration adds `FULLTEXT` indexes on `expenses(title, description, expense_number)` and `expense_items(description, vendor_name)`
- `SearchController` — single invokable controller at `GET /api/v1/search?q=...`
- Boolean mode `MATCH ... AGAINST` with `+word*` prefix expansion for each search token
- Results include matching expenses and expenses whose items match; ranked by MySQL relevance score
- 2-char minimum query length guard; capped at 50 results; tenant-scoped

## Changes

- `expense-management/backend/database/migrations/2024_01_15_000013_add_fulltext_index_to_expenses.php`
- `expense-management/backend/app/Http/Controllers/Api/V1/SearchController.php`

## Test plan

- [ ] `GET /search?q=交通費` returns expenses with that term in title or items
- [ ] Multi-word query (`交通費 東京`) requires ALL tokens (boolean AND)
- [ ] Query shorter than 2 chars returns empty result immediately
- [ ] Results are sorted by relevance score descending
- [ ] Tenant isolation — results only include the authenticated user's tenant data

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_