### PR TITLE
feat: Add Laravel Kernel schedule with 6 recurring tasks

### DIFF
--- a/expense-management/backend/app/Console/Commands/SyncBudgetSpent.php
+++ b/expense-management/backend/app/Console/Commands/SyncBudgetSpent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Budget;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class SyncBudgetSpent extends Command
+{
+    protected $signature   = 'budget:sync-spent';
+    protected $description = 'Recalculate and update the spent amount for all active budgets';
+
+    public function handle(): int
+    {
+        $updated = 0;
+
+        Budget::chunk(200, function ($budgets) use (&$updated) {
+            foreach ($budgets as $budget) {
+                $spent = DB::table('expenses')
+                    ->where('tenant_id', $budget->tenant_id)
+                    ->where('status', 'approved')
+                    ->when($budget->department_id, fn($q) => $q->where('department_id', $budget->department_id))
+                    ->when($budget->category_id, fn($q) => $q->where('category_id', $budget->category_id))
+                    ->whereYear('applied_at', $budget->fiscal_year)
+                    ->sum('total_amount');
+
+                if ($budget->spent !== (int) $spent) {
+                    $budget->update(['spent' => (int) $spent]);
+                    $updated++;
+                }
+            }
+        });
+
+        $this->info("Updated {$updated} budget records.");
+        return self::SUCCESS;
+    }
+}

--- a/expense-management/backend/app/Console/Kernel.php
+++ b/expense-management/backend/app/Console/Kernel.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console;
+
+use App\Jobs\GenerateMonthlyReport;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        // Purge soft-deleted expenses older than 90 days (daily at 02:00 JST)
+        $schedule->command('expense:purge-trash --days=90')
+            ->dailyAt('17:00') // 02:00 JST = 17:00 UTC
+            ->withoutOverlapping()
+            ->runInBackground()
+            ->appendOutputTo(storage_path('logs/schedule.log'));
+
+        // Monthly cost report — generated on 1st of each month at 06:00 JST
+        $schedule->call(function () {
+            $prevMonth = now()->subMonth();
+            GenerateMonthlyReport::dispatch(
+                $prevMonth->year,
+                $prevMonth->month
+            );
+        })
+            ->monthlyOn(1, '21:00') // 06:00 JST = 21:00 UTC previous day
+            ->name('monthly-report')
+            ->withoutOverlapping();
+
+        // Clean up expired Sanctum tokens (daily at 03:00 JST)
+        $schedule->command('sanctum:prune-expired --hours=168') // 7 days
+            ->dailyAt('18:00')
+            ->withoutOverlapping();
+
+        // Clear expired webhook deliveries older than 30 days (weekly)
+        $schedule->command('db:query', [
+            "DELETE FROM webhook_deliveries WHERE created_at < DATE_SUB(NOW(), INTERVAL 30 DAY)",
+        ])
+            ->weekly()
+            ->sundays()
+            ->at('19:00')
+            ->withoutOverlapping();
+
+        // Sync budget spent amounts from approved expenses (every 15 minutes)
+        $schedule->command('budget:sync-spent')
+            ->everyFifteenMinutes()
+            ->withoutOverlapping()
+            ->runInBackground();
+
+        // Queue monitor — restart stuck workers if queue depth exceeds threshold
+        $schedule->command('queue:monitor default,emails,reports,notifications --max=500')
+            ->everyFiveMinutes();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__ . '/Commands');
+
+        require base_path('routes/console.php');
+    }
+}


### PR DESCRIPTION
## Summary

- `Kernel.php` defines 6 scheduled tasks:
  - `expense:purge-trash` — daily 02:00 JST, purges soft-deleted expenses > 90 days
  - `GenerateMonthlyReport::dispatch` — 1st of month 06:00 JST, dispatches previous month's report
  - `sanctum:prune-expired` — daily 03:00 JST, removes expired tokens (7-day TTL)
  - DB query to purge `webhook_deliveries` older than 30 days (weekly Sunday)
  - `budget:sync-spent` — every 15 minutes, recalculates budget spent amounts
  - `queue:monitor` — every 5 minutes, checks queue depth (alerts if > 500)
- `SyncBudgetSpent` Artisan command — chunks budgets in 200, recalculates `spent` from approved expenses

## Changes

- `expense-management/backend/app/Console/Kernel.php`
- `expense-management/backend/app/Console/Commands/SyncBudgetSpent.php`

## Test plan

- [ ] `php artisan schedule:list` shows all 6 tasks with correct cron expressions
- [ ] `budget:sync-spent` updates only budgets where `spent` differs from actual sum
- [ ] `withoutOverlapping()` prevents concurrent runs under load

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_