### PR TITLE
feat: Add pending approval reminder job and dispatch command

### DIFF
--- a/expense-management/backend/app/Console/Commands/DispatchApprovalReminders.php
+++ b/expense-management/backend/app/Console/Commands/DispatchApprovalReminders.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SendPendingApprovalReminder;
+use App\Services\ApprovalPolicyService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DispatchApprovalReminders extends Command
+{
+    protected $signature   = 'expense:dispatch-reminders {--days=3 : Remind after this many days pending}';
+    protected $description = 'Send reminder emails to approvers for expenses pending longer than --days';
+
+    public function __construct(private readonly ApprovalPolicyService $policy)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+
+        $pending = DB::table('expenses')
+            ->whereIn('status', ['submitted', 'pending_approval'])
+            ->where('updated_at', '<=', now()->subDays($days))
+            ->select('id', 'tenant_id', 'applicant_id', 'updated_at')
+            ->get();
+
+        $count = 0;
+
+        foreach ($pending as $row) {
+            $expense = \App\Models\Expense::find($row->id);
+            if (!$expense) continue;
+
+            $approverId = $this->policy->nextApprover($expense);
+            if (!$approverId) continue;
+
+            $daysPending = (int) now()->diffInDays($row->updated_at);
+
+            SendPendingApprovalReminder::dispatch(
+                expenseId:   $row->id,
+                approverId:  $approverId,
+                daysPending: $daysPending,
+            );
+
+            $count++;
+        }
+
+        $this->info("Dispatched {$count} reminder(s) for expenses pending > {$days} days.");
+        return self::SUCCESS;
+    }
+}

--- a/expense-management/backend/app/Jobs/SendPendingApprovalReminder.php
+++ b/expense-management/backend/app/Jobs/SendPendingApprovalReminder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+
+class SendPendingApprovalReminder implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries   = 3;
+    public int $backoff = 300;
+
+    public function __construct(
+        private readonly int $expenseId,
+        private readonly int $approverId,
+        private readonly int $daysPending,
+    ) {
+        $this->onQueue('emails');
+    }
+
+    public function handle(): void
+    {
+        $expense  = Expense::with('applicant')->find($this->expenseId);
+        $approver = User::find($this->approverId);
+
+        if (!$expense || !$approver) {
+            return;
+        }
+
+        // Skip if already approved/rejected since the job was dispatched
+        if (!in_array($expense->status, ['submitted', 'pending_approval'], true)) {
+            return;
+        }
+
+        $approver->notify(new \App\Notifications\PendingApprovalReminder(
+            expense: $expense,
+            daysPending: $this->daysPending,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- `SendPendingApprovalReminder` queued job (`emails` queue, 3 retries, 5min backoff) — sends notification to the next approver in the chain; skips silently if expense was already approved/rejected
- `DispatchApprovalReminders` Artisan command — queries expenses in `submitted`/`pending_approval` status that haven't been updated in `--days` (default 3), resolves next approver via `ApprovalPolicyService`, dispatches reminder job per expense

## Changes

- `expense-management/backend/app/Jobs/SendPendingApprovalReminder.php`
- `expense-management/backend/app/Console/Commands/DispatchApprovalReminders.php`

## Test plan

- [ ] `php artisan expense:dispatch-reminders --days=3` dispatches jobs for stale expenses
- [ ] Job skips if expense status changed to `approved` before the job runs
- [ ] Job skips if approver user is deleted
- [ ] `--days=1` catches same-day pending expenses

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_