### PR TITLE
feat: Add AWS Cost Budget with 80%/100%/120% threshold alerts (Terraform)

### DIFF
--- a/expense-management/terraform/cost_budget.tf
+++ b/expense-management/terraform/cost_budget.tf
@@ -1,0 +1,79 @@
+# AWS Budgets — monthly cost cap with SNS alerts
+resource "aws_budgets_budget" "monthly" {
+  name         = "${local.name_prefix}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = var.monthly_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # Alert at 80% forecast
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_sns_topic_arns  = [aws_sns_topic.alerts.arn]
+  }
+
+  # Alert at 100% actual
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_sns_topic_arns  = [aws_sns_topic.alerts.arn]
+  }
+
+  # Alert at 120% actual (overspend)
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 120
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_sns_topic_arns  = [aws_sns_topic.alerts.arn]
+  }
+
+  tags = local.common_tags
+}
+
+# Per-service budget for RDS (often the largest cost)
+resource "aws_budgets_budget" "rds" {
+  name         = "${local.name_prefix}-rds-budget"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_usd * 0.4)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_filter {
+    name   = "Service"
+    values = ["Amazon Relational Database Service"]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 90
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.alerts.arn]
+  }
+
+  tags = local.common_tags
+}
+
+# SNS topic policy update to allow Budgets service to publish
+resource "aws_sns_topic_policy" "budgets_publish" {
+  arn = aws_sns_topic.alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowBudgetsPublish"
+        Effect    = "Allow"
+        Principal = { Service = "budgets.amazonaws.com" }
+        Action    = "sns:Publish"
+        Resource  = aws_sns_topic.alerts.arn
+      },
+    ]
+  })
+}

--- a/expense-management/terraform/variables_budget.tf
+++ b/expense-management/terraform/variables_budget.tf
@@ -1,0 +1,5 @@
+variable "monthly_budget_usd" {
+  description = "Monthly AWS cost budget in USD. Alerts fire at 80% forecast, 100% and 120% actual."
+  type        = number
+  default     = 500
+}


### PR DESCRIPTION
## Summary

- Monthly cost budget with 3 notification thresholds: 80% forecasted, 100% actual, 120% actual (overspend)
- Per-service RDS budget capped at 40% of monthly total with 90% actual alert
- SNS topic policy updated to allow `budgets.amazonaws.com` to publish alerts
- `monthly_budget_usd` variable (default $500) controls the overall cap

## Changes

- `expense-management/terraform/cost_budget.tf`
- `expense-management/terraform/variables_budget.tf`

## Test plan

- [ ] `terraform plan` shows 2 budgets + SNS policy update
- [ ] Budget notifications route to the existing `alerts` SNS topic
- [ ] RDS budget threshold = `monthly_budget_usd * 0.4`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_