### PR TITLE
feat: Add multi-currency conversion service with cached exchange rates

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/CurrencyController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/CurrencyController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Services\CurrencyConversionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CurrencyController extends Controller
+{
+    public function __construct(private readonly CurrencyConversionService $fx)
+    {
+    }
+
+    public function rates(): JsonResponse
+    {
+        $currencies = $this->fx->getSupportedCurrencies();
+        $rates      = [];
+
+        foreach ($currencies as $currency) {
+            if ($currency !== 'JPY') {
+                $rates[$currency] = $this->fx->getRate($currency);
+            }
+        }
+
+        return response()->json([
+            'base'  => 'JPY',
+            'rates' => $rates,
+        ]);
+    }
+
+    public function convert(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'amount'   => 'required|numeric|min:0',
+            'from'     => 'required|string|size:3',
+            'to'       => 'required|string|size:3',
+        ]);
+
+        $jpy    = $this->fx->toJpy($data['amount'], strtoupper($data['from']));
+        $result = $this->fx->fromJpy($jpy, strtoupper($data['to']));
+
+        return response()->json([
+            'from'   => strtoupper($data['from']),
+            'to'     => strtoupper($data['to']),
+            'amount' => (float) $data['amount'],
+            'result' => $result,
+            'rate'   => round($result / max($data['amount'], 0.0001), 6),
+        ]);
+    }
+}

--- a/expense-management/backend/app/Services/CurrencyConversionService.php
+++ b/expense-management/backend/app/Services/CurrencyConversionService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class CurrencyConversionService
+{
+    private const CACHE_TTL   = 3600; // 1 hour
+    private const CACHE_KEY   = 'exchange_rates_jpy_base';
+    private const FALLBACK    = ['USD' => 150.0, 'EUR' => 163.0, 'GBP' => 190.0, 'CNY' => 21.0];
+
+    /**
+     * Convert an amount in the given currency to JPY.
+     */
+    public function toJpy(int|float $amount, string $fromCurrency): int
+    {
+        if ($fromCurrency === 'JPY') {
+            return (int) round($amount);
+        }
+
+        $rate = $this->getRate($fromCurrency);
+        return (int) round($amount * $rate);
+    }
+
+    /**
+     * Convert an amount in JPY to the target currency.
+     */
+    public function fromJpy(int $amountJpy, string $toCurrency): float
+    {
+        if ($toCurrency === 'JPY') {
+            return (float) $amountJpy;
+        }
+
+        $rate = $this->getRate($toCurrency);
+        return round($amountJpy / $rate, 2);
+    }
+
+    /**
+     * Get the JPY exchange rate for the given currency (JPY per 1 unit of currency).
+     */
+    public function getRate(string $currency): float
+    {
+        $rates = $this->fetchRates();
+        return (float) ($rates[$currency] ?? self::FALLBACK[$currency] ?? 1.0);
+    }
+
+    public function getSupportedCurrencies(): array
+    {
+        return array_keys(array_merge(self::FALLBACK, $this->fetchRates()));
+    }
+
+    private function fetchRates(): array
+    {
+        return Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function () {
+            $apiUrl = config('services.exchange_rate.url', '');
+            $apiKey = config('services.exchange_rate.key', '');
+
+            if (empty($apiUrl) || empty($apiKey)) {
+                Log::warning('Exchange rate API not configured; using fallback rates.');
+                return self::FALLBACK;
+            }
+
+            try {
+                $response = Http::timeout(5)->get($apiUrl, [
+                    'base'    => 'JPY',
+                    'api_key' => $apiKey,
+                ]);
+
+                if ($response->successful()) {
+                    return $response->json('rates', self::FALLBACK);
+                }
+            } catch (\Throwable $e) {
+                Log::error('Failed to fetch exchange rates', ['error' => $e->getMessage()]);
+            }
+
+            return self::FALLBACK;
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- `CurrencyConversionService` — fetches exchange rates from configurable API, caches in Redis for 1 hour, falls back to hardcoded rates (USD/EUR/GBP/CNY) if API is unavailable
- `toJpy()` / `fromJpy()` methods for bidirectional conversion
- `CurrencyController` with two endpoints:
  - `GET /api/v1/currencies/rates` — returns all JPY-base rates
  - `POST /api/v1/currencies/convert` — converts `amount` from one currency to another

## Changes

- `expense-management/backend/app/Services/CurrencyConversionService.php`
- `expense-management/backend/app/Http/Controllers/Api/V1/CurrencyController.php`

## Test plan

- [ ] `GET /currencies/rates` returns rates keyed by 3-letter currency code
- [ ] `POST /currencies/convert` with `{amount: 100, from: "USD", to: "JPY"}` returns correct JPY value
- [ ] Rates are cached — second call within 1 hour does not hit the external API
- [ ] Missing API config logs a warning and uses fallback rates without throwing

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_