### PR TITLE
feat: Add accessible modal, focus-trap hook, and skip-nav link

### DIFF
--- a/expense-management/frontend/src/components/common/AccessibleModal.tsx
+++ b/expense-management/frontend/src/components/common/AccessibleModal.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useId } from 'react';
+import { createPortal } from 'react-dom';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const SIZE_MAP = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-2xl',
+};
+
+export default function AccessibleModal({ open, onClose, title, description, children, size = 'md' }: Props) {
+  const dialogRef = useFocusTrap(open) as React.RefObject<HTMLDivElement>;
+  const titleId   = useId();
+  const descId    = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.activeElement as HTMLElement;
+    document.body.style.overflow = 'hidden';
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      document.body.style.overflow = '';
+      prev?.focus();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="presentation"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descId : undefined}
+        className={`relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl w-full ${SIZE_MAP[size]} p-6 focus:outline-none`}
+        tabIndex={-1}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 id={titleId} className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+            {description && (
+              <p id={descId} className="text-sm text-gray-500 mt-1">{description}</p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="閉じる"
+            className="ml-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-lg p-1 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/expense-management/frontend/src/components/common/SkipNavLink.tsx
+++ b/expense-management/frontend/src/components/common/SkipNavLink.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function SkipNavLink() {
+  return (
+    <a
+      href="#main-content"
+      className=[
+        'sr-only focus:not-sr-only',
+        'focus:absolute focus:top-2 focus:left-2 focus:z-[100]',
+        'px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg',
+        'focus:ring-2 focus:ring-white focus:outline-none',
+      ].join(' ')
+    >
+      メインコンテンツへ移動
+    </a>
+  );
+}

--- a/expense-management/frontend/src/hooks/useFocusTrap.ts
+++ b/expense-management/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE = [
+  'a[href]', 'button:not([disabled])', 'input:not([disabled])',
+  'select:not([disabled])', 'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function useFocusTrap(active: boolean) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!active || !ref.current) return;
+
+    const container = ref.current;
+    const elements  = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE));
+    const first     = elements[0];
+    const last      = elements[elements.length - 1];
+
+    first?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (elements.length === 0) { e.preventDefault(); return; }
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last?.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first?.focus(); }
+      }
+    };
+
+    container.addEventListener('keydown', handleKey);
+    return () => container.removeEventListener('keydown', handleKey);
+  }, [active]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

- `useFocusTrap` hook — traps Tab/Shift+Tab within a container when active; focuses first element on mount
- `AccessibleModal` — WCAG-compliant dialog with `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`; restores focus to trigger element on close; locks body scroll; closes on `Escape`; rendered via `createPortal`
- `SkipNavLink` — visually hidden link that becomes visible on focus, jumping to `#main-content` for keyboard users

## Changes

- `expense-management/frontend/src/hooks/useFocusTrap.ts`
- `expense-management/frontend/src/components/common/AccessibleModal.tsx`
- `expense-management/frontend/src/components/common/SkipNavLink.tsx`

## Test plan

- [ ] Tab key cycles only within the modal while it is open
- [ ] Closing the modal restores focus to the element that opened it
- [ ] `Escape` closes the modal
- [ ] Skip-nav link is invisible until focused (Tab on page load)
- [ ] Screen reader announces dialog title via `aria-labelledby`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_