### PR TITLE
feat: backend expense archive controller and migration

### DIFF
--- a/expense-management/backend/app/Http/Controllers/Api/V1/Admin/ExpenseArchiveController.php
+++ b/expense-management/backend/app/Http/Controllers/Api/V1/Admin/ExpenseArchiveController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ExpenseArchiveController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $archives = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->whereNotNull('archived_at')
+            ->selectRaw('YEAR(archived_at) as year, COUNT(*) as count, SUM(total_amount) as total')
+            ->groupBy('year')
+            ->orderByDesc('year')
+            ->get();
+
+        return response()->json(['data' => $archives]);
+    }
+
+    public function archive(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'fiscal_year' => 'required|integer|min:2000|max:2100',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+        $year     = $data['fiscal_year'];
+
+        $count = Expense::where('tenant_id', $tenantId)
+            ->whereIn('status', ['approved', 'paid'])
+            ->whereYear('applied_at', $year)
+            ->whereNull('archived_at')
+            ->count();
+
+        if ($count === 0) {
+            return response()->json([
+                'message' => "No eligible expenses found for fiscal year {$year}.",
+                'archived' => 0,
+            ]);
+        }
+
+        Expense::where('tenant_id', $tenantId)
+            ->whereIn('status', ['approved', 'paid'])
+            ->whereYear('applied_at', $year)
+            ->whereNull('archived_at')
+            ->update(['archived_at' => now()]);
+
+        return response()->json([
+            'message'  => "Archived {$count} expenses for fiscal year {$year}.",
+            'archived' => $count,
+            'year'     => $year,
+        ]);
+    }
+
+    public function unarchive(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'fiscal_year' => 'required|integer|min:2000|max:2100',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+        $year     = $data['fiscal_year'];
+
+        $count = Expense::where('tenant_id', $tenantId)
+            ->whereYear('applied_at', $year)
+            ->whereNotNull('archived_at')
+            ->update(['archived_at' => null]);
+
+        return response()->json([
+            'message'    => "Unarchived {$count} expenses for fiscal year {$year}.",
+            'unarchived' => $count,
+        ]);
+    }
+}

--- a/expense-management/backend/database/migrations/2024_01_15_000014_add_archived_at_to_expenses.php
+++ b/expense-management/backend/database/migrations/2024_01_15_000014_add_archived_at_to_expenses.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('deleted_at')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropColumn('archived_at');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Add `ExpenseArchiveController` (Admin) with `index`, `archive`, and `unarchive` actions
- `index` returns archive summary grouped by fiscal year with counts and totals
- `archive` bulk-marks `approved`/`paid` expenses for a given fiscal year with `archived_at = now()`
- `unarchive` reverses the archive flag
- Migration adds `archived_at timestamp nullable` with index to expenses table

## Test plan
- [ ] `GET /api/v1/admin/expenses/archive` returns summary grouped by fiscal year
- [ ] `POST /api/v1/admin/expenses/archive` with `fiscal_year` archives matching expenses
- [ ] `DELETE /api/v1/admin/expenses/archive/{year}` unarchives expenses
- [ ] Only `approved`/`paid` expenses are archived
- [ ] Cross-tenant isolation enforced via `tenant_id` scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_