### PR TITLE
feat: frontend notification preferences panel

### DIFF
--- a/expense-management/frontend/src/components/settings/NotificationPreferencesPanel.tsx
+++ b/expense-management/frontend/src/components/settings/NotificationPreferencesPanel.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../../lib/api';
+
+interface Preferences {
+  email_on_submit: boolean;
+  email_on_approve: boolean;
+  email_on_reject: boolean;
+  email_on_comment: boolean;
+  email_on_reminder: boolean;
+  push_on_approve: boolean;
+  push_on_reject: boolean;
+  push_on_comment: boolean;
+  digest_frequency: 'none' | 'daily' | 'weekly';
+}
+
+interface ToggleRowProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}
+
+function ToggleRow({ label, description, checked, onChange, disabled }: ToggleRowProps) {
+  const id = React.useId();
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div className="flex-1 pr-4">
+        <label htmlFor={id} className="text-sm font-medium text-gray-800 dark:text-gray-200 cursor-pointer">
+          {label}
+        </label>
+        {description && <p className="text-xs text-gray-400 mt-0.5">{description}</p>}
+      </div>
+      <button
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+          checked ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform ${
+            checked ? 'translate-x-5' : 'translate-x-0'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export default function NotificationPreferencesPanel() {
+  const qc = useQueryClient();
+  const [saved, setSaved] = useState(false);
+
+  const { data: prefs, isLoading } = useQuery({
+    queryKey: ['notification-preferences'],
+    queryFn: () =>
+      apiClient.get('/api/v1/user/notification-preferences').then(r => r.data.data as Preferences),
+  });
+
+  const [local, setLocal] = useState<Preferences | null>(null);
+  const current = local ?? prefs;
+
+  const toggle = (key: keyof Omit<Preferences, 'digest_frequency'>) =>
+    setLocal(p => ({ ...(p ?? prefs!), [key]: !(p ?? prefs!)[key] }));
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: Preferences) =>
+      apiClient.put('/api/v1/user/notification-preferences', payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notification-preferences'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    },
+  });
+
+  if (isLoading || !current) {
+    return <div className="animate-pulse h-40 bg-gray-100 dark:bg-gray-700 rounded-xl" />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow p-5">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">メール通知</h3>
+        <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          <ToggleRow label="経費申請時" description="自分の申請が提出されたとき" checked={current.email_on_submit} onChange={() => toggle('email_on_submit')} />
+          <ToggleRow label="承認時" description="経費申請が承認されたとき" checked={current.email_on_approve} onChange={() => toggle('email_on_approve')} />
+          <ToggleRow label="却下時" description="経費申請が却下されたとき" checked={current.email_on_reject} onChange={() => toggle('email_on_reject')} />
+          <ToggleRow label="コメント時" checked={current.email_on_comment} onChange={() => toggle('email_on_comment')} />
+          <ToggleRow label="承認リマインダー" description="承認待ちが続く場合にリマインド" checked={current.email_on_reminder} onChange={() => toggle('email_on_reminder')} />
+        </div>
+      </section>
+
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow p-5">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">ブラウザー通知</h3>
+        <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          <ToggleRow label="承認時" checked={current.push_on_approve} onChange={() => toggle('push_on_approve')} />
+          <ToggleRow label="却下時" checked={current.push_on_reject} onChange={() => toggle('push_on_reject')} />
+          <ToggleRow label="コメント時" checked={current.push_on_comment} onChange={() => toggle('push_on_comment')} />
+        </div>
+      </section>
+
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow p-5">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">ダイジェストメール</h3>
+        <select
+          value={current.digest_frequency}
+          onChange={e => setLocal(p => ({ ...(p ?? prefs!), digest_frequency: e.target.value as Preferences['digest_frequency'] }))}
+          className="w-full border rounded px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600"
+        >
+          <option value="none">送信しない</option>
+          <option value="daily">毎日</option>
+          <option value="weekly">毎週</option>
+        </select>
+      </section>
+
+      <div className="flex items-center justify-end gap-3">
+        {saved && <span className="text-sm text-green-600 dark:text-green-400">保存しました</span>}
+        <button
+          onClick={() => saveMutation.mutate(current)}
+          disabled={saveMutation.isPending}
+          className="px-5 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {saveMutation.isPending ? '保存中...' : '設定を保存'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/components/NotificationPreferences.tsx
+++ b/resources/js/components/NotificationPreferences.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface NotificationPreference {
+  key: string;
+  label: string;
+  description: string;
+  channels: {
+    email: boolean;
+    in_app: boolean;
+    push: boolean;
+  };
+}
+
+interface PreferencesResponse {
+  preferences: NotificationPreference[];
+}
+
+const CHANNELS = [
+  { key: 'email', label: 'メール' },
+  { key: 'in_app', label: 'アプリ内' },
+  { key: 'push', label: 'プッシュ' },
+] as const;
+
+type Channel = typeof CHANNELS[number]['key'];
+
+function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label: string }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex w-10 h-5 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+        checked ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
+      }`}
+    >
+      <span className={`inline-block w-4 h-4 rounded-full bg-white shadow transition-transform ${
+        checked ? 'translate-x-5' : 'translate-x-0.5'
+      }`} />
+    </button>
+  );
+}
+
+export function NotificationPreferences() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery<PreferencesResponse>({
+    queryKey: ['notification-preferences'],
+    queryFn: () => fetch('/api/user/notification-preferences').then(r => r.json()),
+  });
+
+  const mutation = useMutation({
+    mutationFn: (preferences: NotificationPreference[]) =>
+      fetch('/api/user/notification-preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preferences }),
+      }).then(r => r.json()),
+    onSuccess: result => {
+      queryClient.setQueryData(['notification-preferences'], result);
+    },
+  });
+
+  function toggle(prefKey: string, channel: Channel, value: boolean) {
+    if (!data) return;
+    const updated = data.preferences.map(p =>
+      p.key === prefKey
+        ? { ...p, channels: { ...p.channels, [channel]: value } }
+        : p
+    );
+    mutation.mutate(updated);
+  }
+
+  function toggleAll(channel: Channel, value: boolean) {
+    if (!data) return;
+    const updated = data.preferences.map(p => ({
+      ...p,
+      channels: { ...p.channels, [channel]: value },
+    }));
+    mutation.mutate(updated);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-16 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  const prefs = data?.preferences ?? [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        受け取りた通知と配信方法を設定してください。
+      </p>
+
+      {/* Header row */}
+      <div className="hidden sm:grid sm:grid-cols-[1fr_repeat(3,auto)] sm:gap-6 px-4 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+        <span>通知の種類</span>
+        {CHANNELS.map(ch => (
+          <div key={ch.key} className="flex flex-col items-center gap-1 w-14">
+            <span>{ch.label}</span>
+            <Toggle
+              checked={prefs.every(p => p.channels[ch.key])}
+              onChange={v => toggleAll(ch.key, v)}
+              label={`すべて${ch.label}を${prefs.every(p => p.channels[ch.key]) ? 'OFF' : 'ON'}`}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Preference rows */}
+      <div className="divide-y divide-gray-100 dark:divide-gray-800">
+        {prefs.map(pref => (
+          <div
+            key={pref.key}
+            className="grid grid-cols-1 sm:grid-cols-[1fr_repeat(3,auto)] gap-3 sm:gap-6 items-center py-4 px-4"
+          >
+            <div>
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{pref.label}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{pref.description}</p>
+            </div>
+
+            {CHANNELS.map(ch => (
+              <div key={ch.key} className="flex items-center justify-between sm:justify-center sm:w-14">
+                <span className="text-xs text-gray-500 sm:hidden">{ch.label}</span>
+                <Toggle
+                  checked={pref.channels[ch.key]}
+                  onChange={v => toggle(pref.key, ch.key, v)}
+                  label={`${pref.label}の${ch.label}通知を${pref.channels[ch.key] ? '無効' : '有効'}にする`}
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {mutation.isError && (
+        <p className="text-sm text-red-500">設定の保存に失敗しました。再度お試しください。</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `NotificationPreferencesPanel.tsx` with ARIA-compliant toggle switches
- Covers 5 email notification types (submit/approve/reject/comment/reminder) and 3 push types
- Digest frequency dropdown (none/daily/weekly)
- Fetches current prefs via `GET /api/v1/user/notification-preferences`
- Saves changes via `PUT` with success flash message
- All toggles use `role="switch"` + `aria-checked` for accessibility

## Test plan
- [ ] Preferences load on mount
- [ ] Toggle switches update local state immediately (optimistic)
- [ ] Save button calls PUT endpoint
- [ ] Success flash appears on save
- [ ] Digest frequency dropdown persists selection

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_