### PR TITLE
feat: backend recurring expense templates with queued generation

### DIFF
--- a/app/Http/Controllers/Api/RecurringExpenseController.php
+++ b/app/Http/Controllers/Api/RecurringExpenseController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\RecurringExpenseTemplate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RecurringExpenseController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $templates = RecurringExpenseTemplate::where('tenant_id', Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->with('category:id,name,color')
+            ->orderBy('next_run_date')
+            ->paginate(20);
+
+        return response()->json($templates);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'title'              => 'required|string|max:255',
+            'description'        => 'nullable|string|max:1000',
+            'category_id'        => 'required|integer|exists:expense_categories,id',
+            'amount'             => 'required|numeric|min:0.01|max:99999999.99',
+            'currency'           => 'nullable|string|size:3',
+            'frequency'          => 'required|in:daily,weekly,monthly,quarterly,yearly',
+            'frequency_interval' => 'nullable|integer|min:1|max:365',
+            'start_date'         => 'required|date|after_or_equal:today',
+            'end_date'           => 'nullable|date|after:start_date',
+        ]);
+
+        $template = RecurringExpenseTemplate::create([
+            ...$data,
+            'tenant_id'     => Auth::user()->tenant_id,
+            'user_id'       => Auth::id(),
+            'next_run_date' => $data['start_date'],
+            'currency'      => $data['currency'] ?? 'JPY',
+            'frequency_interval' => $data['frequency_interval'] ?? 1,
+        ]);
+
+        return response()->json($template->load('category:id,name,color'), 201);
+    }
+
+    public function update(Request $request, RecurringExpenseTemplate $template): JsonResponse
+    {
+        $this->authorizeTemplate($template);
+
+        $data = $request->validate([
+            'title'       => 'sometimes|string|max:255',
+            'description' => 'nullable|string|max:1000',
+            'amount'      => 'sometimes|numeric|min:0.01',
+            'end_date'    => 'nullable|date|after:start_date',
+            'is_active'   => 'sometimes|boolean',
+        ]);
+
+        $template->update($data);
+
+        return response()->json($template->fresh('category:id,name,color'));
+    }
+
+    public function destroy(RecurringExpenseTemplate $template): JsonResponse
+    {
+        $this->authorizeTemplate($template);
+        $template->delete();
+
+        return response()->json(null, 204);
+    }
+
+    public function runNow(RecurringExpenseTemplate $template): JsonResponse
+    {
+        $this->authorizeTemplate($template);
+
+        \App\Jobs\GenerateRecurringExpense::dispatch($template);
+
+        return response()->json(['message' => 'Expense generation queued.']);
+    }
+
+    private function authorizeTemplate(RecurringExpenseTemplate $template): void
+    {
+        abort_unless(
+            $template->tenant_id === Auth::user()->tenant_id && $template->user_id === Auth::id(),
+            403
+        );
+    }
+}

--- a/app/Jobs/GenerateRecurringExpense.php
+++ b/app/Jobs/GenerateRecurringExpense.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Expense;
+use App\Models\RecurringExpenseTemplate;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class GenerateRecurringExpense implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $backoff = 60;
+
+    public function __construct(private readonly RecurringExpenseTemplate $template) {}
+
+    public function handle(): void
+    {
+        DB::transaction(function () {
+            Expense::create([
+                'tenant_id'   => $this->template->tenant_id,
+                'user_id'     => $this->template->user_id,
+                'category_id' => $this->template->category_id,
+                'title'       => $this->template->title,
+                'description' => $this->template->description,
+                'amount'      => $this->template->amount,
+                'currency'    => $this->template->currency,
+                'status'      => 'draft',
+                'expense_date'=> now()->toDateString(),
+                'metadata'    => array_merge(
+                    $this->template->metadata ?? [],
+                    ['generated_from_template_id' => $this->template->id]
+                ),
+            ]);
+
+            $this->template->update([
+                'last_run_date' => now()->toDateString(),
+                'next_run_date' => $this->template->calculateNextRunDate()->toDateString(),
+            ]);
+        });
+    }
+}

--- a/app/Models/RecurringExpenseTemplate.php
+++ b/app/Models/RecurringExpenseTemplate.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class RecurringExpenseTemplate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'title',
+        'description',
+        'category_id',
+        'amount',
+        'currency',
+        'frequency',
+        'frequency_interval',
+        'start_date',
+        'end_date',
+        'next_run_date',
+        'last_run_date',
+        'is_active',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'amount'             => 'decimal:2',
+        'start_date'         => 'date',
+        'end_date'           => 'date',
+        'next_run_date'      => 'date',
+        'last_run_date'      => 'date',
+        'is_active'          => 'boolean',
+        'metadata'           => 'array',
+        'frequency_interval' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ExpenseCategory::class);
+    }
+
+    public function calculateNextRunDate(): \Carbon\Carbon
+    {
+        $base = $this->next_run_date ?? now();
+        $interval = $this->frequency_interval;
+
+        return match ($this->frequency) {
+            'daily'     => $base->copy()->addDays($interval),
+            'weekly'    => $base->copy()->addWeeks($interval),
+            'monthly'   => $base->copy()->addMonths($interval),
+            'quarterly' => $base->copy()->addMonths($interval * 3),
+            'yearly'    => $base->copy()->addYears($interval),
+        };
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true)
+                     ->where('next_run_date', '<=', now()->toDateString())
+                     ->where(function ($q) {
+                         $q->whereNull('end_date')
+                           ->orWhere('end_date', '>=', now()->toDateString());
+                     });
+    }
+}

--- a/database/migrations/2024_01_15_000015_create_recurring_expense_templates_table.php
+++ b/database/migrations/2024_01_15_000015_create_recurring_expense_templates_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('recurring_expense_templates', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('user_id');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('category_id');
+            $table->decimal('amount', 12, 2);
+            $table->char('currency', 3)->default('JPY');
+            $table->enum('frequency', ['daily', 'weekly', 'monthly', 'quarterly', 'yearly']);
+            $table->unsignedTinyInteger('frequency_interval')->default(1);
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->date('next_run_date')->index();
+            $table->date('last_run_date')->nullable();
+            $table->boolean('is_active')->default(true)->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'is_active', 'next_run_date']);
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('category_id')->references('id')->on('expense_categories');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recurring_expense_templates');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `recurring_expense_templates` migration with frequency/interval/next_run_date columns
- Add `RecurringExpenseTemplate` model with `calculateNextRunDate()` and `scopeActive()` scope
- Add `RecurringExpenseController` (CRUD + `runNow` endpoint)
- Add `GenerateRecurringExpense` queued job — creates draft expense in a DB transaction, then advances `next_run_date`
- Supports frequencies: daily / weekly / monthly / quarterly / yearly with configurable intervals
- Cross-tenant isolation: all queries scoped by `tenant_id` + `user_id`

## Test plan
- [ ] `POST /api/v1/recurring-expenses` creates a template with `next_run_date = start_date`
- [ ] `POST /api/v1/recurring-expenses/{id}/run` dispatches `GenerateRecurringExpense` job
- [ ] Job creates a draft expense and advances `next_run_date` correctly for each frequency
- [ ] `PATCH /api/v1/recurring-expenses/{id}` updates `is_active` to pause/resume
- [ ] `scopeActive()` excludes templates past their `end_date`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_