### PR TITLE
feat: Terraform WAFv2 WebACL for CloudFront with managed rule groups

### DIFF
--- a/terraform/cloudfront_waf.tf
+++ b/terraform/cloudfront_waf.tf
@@ -1,0 +1,152 @@
+# WAFv2 WebACL for CloudFront — must be in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider    = aws.us_east_1
+  name        = "${var.project_name}-cloudfront-waf"
+  description = "WAFv2 rules for CloudFront distribution"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # AWS Managed Rules: Common Rule Set
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name          = "SizeRestrictions_BODY"
+          action_to_use { allow {} }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules: Known Bad Inputs
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules: SQL Injection
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "SQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rate limit: 2000 req/5min per IP
+  rule {
+    name     = "RateLimitPerIP"
+    priority = 40
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitPerIP"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Geo-block — customise country list via variable
+  dynamic "rule" {
+    for_each = length(var.waf_blocked_countries) > 0 ? [1] : []
+    content {
+      name     = "GeoBlockRule"
+      priority = 50
+
+      action {
+        block {}
+      }
+
+      statement {
+        geo_match_statement {
+          country_codes = var.waf_blocked_countries
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "GeoBlock"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project_name}-cloudfront-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.common_tags
+}
+
+# Associate WebACL with CloudFront is done in cloudfront.tf via web_acl_id
+output "cloudfront_waf_acl_arn" {
+  description = "ARN of the CloudFront WAFv2 WebACL (pass to CloudFront module)"
+  value       = aws_wafv2_web_acl.cloudfront.arn
+}

--- a/terraform/variables_waf.tf
+++ b/terraform/variables_waf.tf
@@ -1,0 +1,5 @@
+variable "waf_blocked_countries" {
+  description = "ISO 3166-1 alpha-2 country codes to geo-block at CloudFront WAF"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

- Add `cloudfront_waf.tf` deploying WAFv2 WebACL in `us-east-1` (required for CloudFront scope)
- Managed rule groups: `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet`, `AWSManagedRulesSQLiRuleSet`
- Rate-based rule: block IPs exceeding 2000 requests per 5 minutes
- Optional geo-block via `waf_blocked_countries` variable (empty = no geo-block)
- Outputs `cloudfront_waf_acl_arn` for use in CloudFront resource `web_acl_id`
- All rules have CloudWatch metric + sampled requests enabled

## Test plan
- [ ] `terraform plan` in `us-east-1` succeeds with no errors
- [ ] WebACL scope is `CLOUDFRONT` (not `REGIONAL`)
- [ ] Rate-limit rule blocks IPs at 2000 req/5min threshold
- [ ] Geo-block rule only created when `waf_blocked_countries` is non-empty

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_