### PR TITLE
feat: backend approval history API with step audit trail and statistics

### DIFF
--- a/app/Http/Controllers/Api/ApprovalHistoryController.php
+++ b/app/Http/Controllers/Api/ApprovalHistoryController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Expense;
+use App\Models\ApprovalStep;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ApprovalHistoryController extends Controller
+{
+    public function forExpense(Expense $expense): JsonResponse
+    {
+        abort_unless($expense->tenant_id === Auth::user()->tenant_id, 404);
+
+        $steps = ApprovalStep::where('expense_id', $expense->id)
+            ->with('approver:id,name,email')
+            ->orderBy('step_order')
+            ->get()
+            ->map(fn($step) => [
+                'id'           => $step->id,
+                'step_order'   => $step->step_order,
+                'step_name'    => $step->step_name,
+                'status'       => $step->status,
+                'approver'     => $step->approver ? [
+                    'id'    => $step->approver->id,
+                    'name'  => $step->approver->name,
+                    'email' => $step->approver->email,
+                ] : null,
+                'comment'      => $step->comment,
+                'decided_at'   => $step->decided_at?->toIso8601String(),
+                'is_current'   => $step->status === 'pending' && $step->step_order === $this->currentStepOrder($expense->id),
+            ]);
+
+        return response()->json([
+            'expense_id'     => $expense->id,
+            'expense_status' => $expense->status,
+            'steps'          => $steps,
+            'summary' => [
+                'total_steps'    => $steps->count(),
+                'completed'      => $steps->where('status', 'approved')->count(),
+                'pending'        => $steps->where('status', 'pending')->count(),
+                'rejected'       => $steps->where('status', 'rejected')->count(),
+            ],
+        ]);
+    }
+
+    public function pendingForUser(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+
+        $pending = ApprovalStep::where('approver_id', $user->id)
+            ->where('status', 'pending')
+            ->whereHas('expense', fn($q) => $q->where('tenant_id', $user->tenant_id)->where('status', 'pending'))
+            ->with([
+                'expense:id,title,amount,currency,expense_date,user_id,status',
+                'expense.submitter:id,name',
+            ])
+            ->orderBy('created_at')
+            ->paginate(20);
+
+        return response()->json($pending);
+    }
+
+    public function statistics(Request $request): JsonResponse
+    {
+        $request->validate([
+            'start_date' => 'nullable|date',
+            'end_date'   => 'nullable|date|after_or_equal:start_date',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        $stats = DB::table('approval_steps as s')
+            ->join('expenses as e', 's.expense_id', '=', 'e.id')
+            ->where('e.tenant_id', $tenantId)
+            ->when($request->start_date, fn($q) => $q->where('s.decided_at', '>=', $request->start_date))
+            ->when($request->end_date, fn($q) => $q->where('s.decided_at', '<=', $request->end_date))
+            ->whereIn('s.status', ['approved', 'rejected'])
+            ->selectRaw(
+                'COUNT(*) as total_decisions,
+                 SUM(CASE WHEN s.status = "approved" THEN 1 ELSE 0 END) as total_approved,
+                 SUM(CASE WHEN s.status = "rejected" THEN 1 ELSE 0 END) as total_rejected,
+                 AVG(TIMESTAMPDIFF(HOUR, e.submitted_at, s.decided_at)) as avg_hours_to_decide'
+            )
+            ->first();
+
+        return response()->json([
+            'total_decisions'    => (int) ($stats->total_decisions ?? 0),
+            'total_approved'     => (int) ($stats->total_approved ?? 0),
+            'total_rejected'     => (int) ($stats->total_rejected ?? 0),
+            'approval_rate'      => $stats->total_decisions > 0
+                ? round($stats->total_approved / $stats->total_decisions * 100, 1)
+                : 0,
+            'avg_hours_to_decide' => round((float) ($stats->avg_hours_to_decide ?? 0), 1),
+        ]);
+    }
+
+    private function currentStepOrder(int $expenseId): int
+    {
+        return (int) ApprovalStep::where('expense_id', $expenseId)
+            ->where('status', 'pending')
+            ->min('step_order');
+    }
+}

--- a/database/migrations/2024_01_15_000016_create_approval_steps_table.php
+++ b/database/migrations/2024_01_15_000016_create_approval_steps_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('approval_steps', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('expense_id')->index();
+            $table->unsignedBigInteger('approver_id')->nullable();
+            $table->unsignedTinyInteger('step_order');
+            $table->string('step_name');
+            $table->enum('status', ['pending', 'approved', 'rejected', 'skipped'])->default('pending');
+            $table->text('comment')->nullable();
+            $table->timestamp('decided_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['expense_id', 'step_order']);
+            $table->index(['approver_id', 'status']);
+            $table->foreign('expense_id')->references('id')->on('expenses')->cascadeOnDelete();
+            $table->foreign('approver_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_steps');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `approval_steps` migration — tracks each step of an approval flow with `step_order`, `status`, `comment`, `decided_at`
- Add `ApprovalHistoryController` with 3 endpoints:
  - `GET /api/v1/expenses/{id}/approval-history` — full step-by-step audit trail with `is_current` flag on the active step
  - `GET /api/v1/approvals/pending` — paginated list of expenses awaiting the authenticated user's decision
  - `GET /api/v1/approvals/statistics` — approval rate, rejection count, avg hours to decision over a date range
- Steps use `cascadeOnDelete` so history is removed when an expense is deleted

## Test plan
- [ ] History endpoint returns all steps in `step_order` order
- [ ] `is_current` is true only for the lowest-order `pending` step
- [ ] Pending list only shows expenses assigned to the authenticated approver
- [ ] Statistics `approval_rate` is `approved / total * 100`
- [ ] Cross-tenant expenses return 404

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_