### PR TITLE
feat: Terraform ElastiCache Redis replication group with multi-AZ and encryption

### DIFF
--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,114 @@
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.project_name}-redis-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = var.common_tags
+}
+
+resource "aws_security_group" "redis" {
+  name        = "${var.project_name}-redis-sg"
+  description = "ElastiCache Redis security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "Redis from ECS tasks"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-redis-sg" })
+}
+
+resource "aws_kms_key" "redis" {
+  description             = "KMS key for ElastiCache Redis encryption at rest"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-redis-kms" })
+}
+
+resource "aws_kms_alias" "redis" {
+  name          = "alias/${var.project_name}-redis"
+  target_key_id = aws_kms_key.redis.key_id
+}
+
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.project_name}-redis"
+  description          = "Redis replication group for ${var.project_name}"
+
+  node_type            = var.redis_node_type
+  num_cache_clusters   = var.redis_num_replicas + 1
+  engine_version       = "7.1"
+  port                 = 6379
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [aws_security_group.redis.id]
+
+  # Encryption
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  kms_key_id                 = aws_kms_key.redis.arn
+  auth_token                 = var.redis_auth_token
+
+  # High availability
+  automatic_failover_enabled = var.redis_num_replicas >= 1
+  multi_az_enabled           = var.redis_num_replicas >= 1
+
+  # Maintenance
+  maintenance_window       = "sun:02:00-sun:04:00"
+  snapshot_window          = "00:00-02:00"
+  snapshot_retention_limit = 7
+
+  # Logging
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_engine_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+
+  apply_immediately          = false
+  auto_minor_version_upgrade = true
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_log_group" "redis_slow_log" {
+  name              = "/elasticache/${var.project_name}/slow-log"
+  retention_in_days = 30
+  tags              = var.common_tags
+}
+
+resource "aws_cloudwatch_log_group" "redis_engine_log" {
+  name              = "/elasticache/${var.project_name}/engine-log"
+  retention_in_days = 14
+  tags              = var.common_tags
+}
+
+output "redis_primary_endpoint" {
+  description = "Redis primary endpoint address"
+  value       = aws_elasticache_replication_group.main.primary_endpoint_address
+  sensitive   = true
+}
+
+output "redis_reader_endpoint" {
+  description = "Redis reader endpoint address"
+  value       = aws_elasticache_replication_group.main.reader_endpoint_address
+  sensitive   = true
+}

--- a/terraform/variables_elasticache.tf
+++ b/terraform/variables_elasticache.tf
@@ -1,0 +1,22 @@
+variable "redis_node_type" {
+  description = "ElastiCache Redis node type"
+  type        = string
+  default     = "cache.t4g.medium"
+}
+
+variable "redis_num_replicas" {
+  description = "Number of read replicas (0 = standalone, 1+ = multi-AZ)"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.redis_num_replicas >= 0 && var.redis_num_replicas <= 5
+    error_message = "redis_num_replicas must be between 0 and 5."
+  }
+}
+
+variable "redis_auth_token" {
+  description = "Redis AUTH token for in-transit encryption (min 16 chars)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- Add `elasticache.tf` with a Redis 7.1 replication group
- Dedicated subnet group and security group (ingress only from ECS tasks SG)
- KMS key for at-rest encryption + AUTH token for in-transit encryption
- `automatic_failover_enabled` and `multi_az_enabled` activated when `redis_num_replicas >= 1`
- CloudWatch log delivery for both slow-log and engine-log (JSON format, 14–30d retention)
- 7-day snapshot retention with maintenance window `sun:02:00-04:00`
- Outputs: `redis_primary_endpoint` and `redis_reader_endpoint` (both sensitive)
- `variables_elasticache.tf` with node type, replica count, and AUTH token variables

## Test plan
- [ ] `terraform plan` shows no errors
- [ ] Single-node mode (`redis_num_replicas = 0`) disables auto-failover
- [ ] Reader endpoint differs from primary when replicas > 0
- [ ] Security group blocks all non-ECS ingress on port 6379

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_