### PR TITLE
docs: add OpenAPI 3.0 specification for expense management API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,301 @@
+openapi: 3.0.3
+info:
+  title: Expense Management API
+  description: |
+    Multi-tenant expense management API for SMEs.
+    All endpoints require Bearer token authentication unless noted.
+    All data is scoped to the authenticated user's tenant.
+  version: 1.0.0
+  contact:
+    name: API Support
+    email: api-support@example.com
+
+servers:
+  - url: https://api.example.com/api/v1
+    description: Production
+  - url: http://localhost:8000/api/v1
+    description: Local development
+
+security:
+  - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Expense:
+      type: object
+      properties:
+        id:           { type: integer, example: 1 }
+        title:        { type: string, example: "Team lunch" }
+        description:  { type: string, nullable: true }
+        amount:       { type: number, format: float, example: 12500.00 }
+        currency:     { type: string, example: "JPY" }
+        status:
+          type: string
+          enum: [draft, pending, approved, rejected, paid, archived]
+        expense_date: { type: string, format: date, example: "2024-01-15" }
+        category:
+          $ref: '#/components/schemas/Category'
+        submitted_at: { type: string, format: date-time, nullable: true }
+        created_at:   { type: string, format: date-time }
+        updated_at:   { type: string, format: date-time }
+
+    ExpenseCreate:
+      type: object
+      required: [title, amount, category_id, expense_date]
+      properties:
+        title:        { type: string, maxLength: 255 }
+        description:  { type: string, maxLength: 2000, nullable: true }
+        amount:       { type: number, minimum: 0.01 }
+        currency:     { type: string, default: "JPY" }
+        category_id:  { type: integer }
+        expense_date: { type: string, format: date }
+
+    Category:
+      type: object
+      properties:
+        id:    { type: integer }
+        name:  { type: string }
+        color: { type: string, example: "#6366f1" }
+
+    User:
+      type: object
+      properties:
+        id:    { type: integer }
+        name:  { type: string }
+        email: { type: string, format: email }
+        role:  { type: string, enum: [user, manager, admin] }
+
+    Pagination:
+      type: object
+      properties:
+        current_page: { type: integer }
+        last_page:    { type: integer }
+        per_page:     { type: integer }
+        total:        { type: integer }
+
+    Error:
+      type: object
+      properties:
+        message: { type: string }
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items: { type: string }
+
+paths:
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate and receive access token
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:    { type: string, format: email }
+                password: { type: string, format: password }
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token: { type: string }
+                  user:  { $ref: '#/components/schemas/User' }
+        '401': { description: Invalid credentials }
+        '422': { description: Validation error, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: Revoke current access token
+      responses:
+        '200': { description: Logged out }
+        '401': { description: Unauthenticated }
+
+  /me:
+    get:
+      tags: [Auth]
+      summary: Get authenticated user profile
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/User' }
+
+  /expenses:
+    get:
+      tags: [Expenses]
+      summary: List expenses with filters and pagination
+      parameters:
+        - in: query
+          name: status
+          schema: { type: string, enum: [draft, pending, approved, rejected, paid, archived] }
+        - in: query
+          name: category_id
+          schema: { type: integer }
+        - in: query
+          name: start_date
+          schema: { type: string, format: date }
+        - in: query
+          name: end_date
+          schema: { type: string, format: date }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: per_page
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        '200':
+          description: Paginated expense list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Pagination'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/Expense' }
+    post:
+      tags: [Expenses]
+      summary: Create a new expense
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExpenseCreate' }
+      responses:
+        '201':
+          description: Created expense
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Expense' }
+        '422': { description: Validation error }
+
+  /expenses/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema: { type: integer }
+    get:
+      tags: [Expenses]
+      summary: Get a single expense
+      responses:
+        '200': { description: Expense detail, content: { application/json: { schema: { $ref: '#/components/schemas/Expense' } } } }
+        '404': { description: Not found }
+    patch:
+      tags: [Expenses]
+      summary: Update a draft expense
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExpenseCreate' }
+      responses:
+        '200': { description: Updated expense }
+        '403': { description: Cannot edit non-draft expense }
+    delete:
+      tags: [Expenses]
+      summary: Delete a draft expense
+      responses:
+        '204': { description: Deleted }
+        '403': { description: Cannot delete non-draft expense }
+
+  /expenses/{id}/submit:
+    post:
+      tags: [Expenses]
+      summary: Submit a draft expense for approval
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+      responses:
+        '200': { description: Expense submitted }
+        '409': { description: Expense is not in draft status }
+
+  /expenses/{id}/approve:
+    post:
+      tags: [Approvals]
+      summary: Approve an expense (approver only)
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment: { type: string }
+      responses:
+        '200': { description: Approved }
+        '403': { description: Not the designated approver }
+
+  /expenses/{id}/reject:
+    post:
+      tags: [Approvals]
+      summary: Reject an expense with mandatory comment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [comment]
+              properties:
+                comment: { type: string, minLength: 1 }
+      responses:
+        '200': { description: Rejected }
+
+  /reports/monthly:
+    get:
+      tags: [Reports]
+      summary: Monthly expense breakdown
+      parameters:
+        - in: query
+          name: year
+          required: true
+          schema: { type: integer }
+      responses:
+        '200': { description: 12-month breakdown with totals }
+
+  /reports/category-breakdown:
+    get:
+      tags: [Reports]
+      summary: Expense totals grouped by category
+      parameters:
+        - in: query
+          name: start_date
+          required: true
+          schema: { type: string, format: date }
+        - in: query
+          name: end_date
+          required: true
+          schema: { type: string, format: date }
+      responses:
+        '200': { description: Category breakdown with percentages }


### PR DESCRIPTION
## Summary

- Add `docs/openapi.yaml` — full OpenAPI 3.0.3 specification
- Schemas: `Expense`, `ExpenseCreate`, `Category`, `User`, `Pagination`, `Error`
- Auth endpoints: POST `/auth/login`, POST `/auth/logout`, GET `/me`
- Expense CRUD: GET/POST `/expenses`, GET/PATCH/DELETE `/expenses/{id}`
- Approval actions: POST `/expenses/{id}/submit`, `/approve`, `/reject`
- Report endpoints: GET `/reports/monthly`, `/reports/category-breakdown`
- Bearer token security applied globally; login endpoint explicitly overrides to no-auth
- Servers: production `https://api.example.com/api/v1` and local dev `http://localhost:8000/api/v1`

## Test plan
- [ ] Validate with `swagger-cli validate docs/openapi.yaml`
- [ ] All `$ref` references resolve without circular dependencies
- [ ] `login` endpoint has `security: []` override (no auth required)
- [ ] `ExpenseCreate` schema marks `title`, `amount`, `category_id`, `expense_date` as required

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_