### PR TITLE
feat: frontend zero-dependency virtual list for large expense datasets

### DIFF
--- a/resources/js/components/VirtualExpenseList.tsx
+++ b/resources/js/components/VirtualExpenseList.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import VirtualList from './VirtualList';
+
+interface Expense {
+  id: number;
+  title: string;
+  amount: number;
+  currency: string;
+  status: string;
+  expense_date: string;
+  category?: { name: string; color: string };
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  draft:    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  pending:  'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  approved: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  rejected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  paid:     'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+};
+
+function ExpenseRow({ expense, onClick }: { expense: Expense; onClick: (id: number) => void }) {
+  const fmt = new Intl.NumberFormat('ja-JP', { style: 'currency', currency: expense.currency });
+
+  return (
+    <button
+      onClick={() => onClick(expense.id)}
+      className="w-full flex items-center gap-4 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors border-b border-gray-100 dark:border-gray-700/50 text-left"
+    >
+      {expense.category && (
+        <span
+          className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+          style={{ background: expense.category.color }}
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{expense.title}</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {expense.expense_date}
+          {expense.category && ` · ${expense.category.name}`}
+        </p>
+      </div>
+      <div className="flex items-center gap-3 flex-shrink-0">
+        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[expense.status] ?? ''}`}>
+          {expense.status}
+        </span>
+        <span className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+          {fmt.format(expense.amount)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+interface Props {
+  expenses: Expense[];
+  onExpenseClick: (id: number) => void;
+  onLoadMore?: () => void;
+  containerHeight?: number;
+}
+
+export default function VirtualExpenseList({ expenses, onExpenseClick, onLoadMore, containerHeight = 600 }: Props) {
+  if (expenses.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-48 text-gray-500 dark:text-gray-400 text-sm">
+        No expenses found.
+      </div>
+    );
+  }
+
+  return (
+    <VirtualList
+      items={expenses}
+      itemHeight={64}
+      containerHeight={containerHeight}
+      onScrollBottom={onLoadMore}
+      renderItem={(expense, _index) => (
+        <ExpenseRow expense={expense} onClick={onExpenseClick} />
+      )}
+    />
+  );
+}

--- a/resources/js/components/VirtualList.tsx
+++ b/resources/js/components/VirtualList.tsx
@@ -1,0 +1,70 @@
+import React, { useRef, useState, useEffect, useCallback, UIEvent } from 'react';
+
+interface VirtualListProps<T> {
+  items: T[];
+  itemHeight: number;
+  containerHeight: number;
+  renderItem: (item: T, index: number) => React.ReactNode;
+  overscan?: number;
+  className?: string;
+  onScrollBottom?: () => void;
+  scrollBottomThreshold?: number;
+}
+
+export default function VirtualList<T>({
+  items,
+  itemHeight,
+  containerHeight,
+  renderItem,
+  overscan = 5,
+  className = '',
+  onScrollBottom,
+  scrollBottomThreshold = 200,
+}: VirtualListProps<T>) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const totalHeight = items.length * itemHeight;
+
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+  const visibleCount = Math.ceil(containerHeight / itemHeight);
+  const endIndex   = Math.min(items.length - 1, startIndex + visibleCount + overscan * 2);
+
+  const visibleItems = items.slice(startIndex, endIndex + 1);
+  const offsetY = startIndex * itemHeight;
+
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    const { scrollTop: st, scrollHeight, clientHeight } = e.currentTarget;
+    setScrollTop(st);
+
+    if (onScrollBottom && scrollHeight - st - clientHeight < scrollBottomThreshold) {
+      onScrollBottom();
+    }
+  }, [onScrollBottom, scrollBottomThreshold]);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+      setScrollTop(0);
+    }
+  }, [items.length === 0]);
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className={`overflow-y-auto ${className}`}
+      style={{ height: containerHeight }}
+    >
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        <div style={{ position: 'absolute', top: offsetY, left: 0, right: 0 }}>
+          {visibleItems.map((item, i) => (
+            <div key={startIndex + i} style={{ height: itemHeight }}>
+              {renderItem(item, startIndex + i)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `VirtualList.tsx` — generic windowed list renderer (no external deps)
  - Calculates visible window from `scrollTop`, `itemHeight`, `containerHeight`
  - Configurable `overscan` rows above/below viewport (default 5)
  - `onScrollBottom` callback fires when scroll distance to bottom < threshold (default 200px)
  - Uses absolute positioning with single `offsetY` transform — no individual item translation
- Add `VirtualExpenseList.tsx` — expense-specific wrapper
  - Status color badges, category dot indicator, Intl.NumberFormat currency display
  - 64px row height, 600px default container
  - Passes `onLoadMore` to `onScrollBottom` for infinite-scroll pagination

## Test plan
- [ ] Renders only visible + overscan items (not the full list)
- [ ] Total container height equals `items.length * itemHeight`
- [ ] `onScrollBottom` fires when scrolled near end
- [ ] Empty state shows "No expenses found" message
- [ ] Works with 10,000+ items without layout thrashing

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_