### PR TITLE
feat: frontend expense form autosave with debounce and save status indicator

### DIFF
--- a/resources/js/components/AutosaveIndicator.tsx
+++ b/resources/js/components/AutosaveIndicator.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface Props {
+  status: SaveStatus;
+  lastSavedAt: Date | null;
+}
+
+export default function AutosaveIndicator({ status, lastSavedAt }: Props) {
+  if (status === 'idle') return null;
+
+  const formatTime = (d: Date) =>
+    d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  return (
+    <div className="inline-flex items-center gap-1.5 text-xs">
+      {status === 'saving' && (
+        <>
+          <span className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+          <span className="text-yellow-600 dark:text-yellow-400">Saving...</span>
+        </>
+      )}
+      {status === 'saved' && (
+        <>
+          <svg className="w-3.5 h-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+          </svg>
+          <span className="text-green-600 dark:text-green-400">
+            Saved{lastSavedAt ? ` at ${formatTime(lastSavedAt)}` : ''}
+          </span>
+        </>
+      )}
+      {status === 'error' && (
+        <>
+          <svg className="w-3.5 h-3.5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-red-600 dark:text-red-400">Save failed</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/resources/js/hooks/useExpenseAutosave.ts
+++ b/resources/js/hooks/useExpenseAutosave.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface AutosaveOptions {
+  expenseId?: number;
+  debounceMs?: number;
+  onSaveSuccess?: (data: Record<string, unknown>) => void;
+  onSaveError?: (err: Error) => void;
+}
+
+interface AutosaveResult {
+  saveStatus: SaveStatus;
+  lastSavedAt: Date | null;
+  triggerSave: (data: Record<string, unknown>) => void;
+}
+
+async function saveDraft(expenseId: number | undefined, data: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const url    = expenseId ? `/api/v1/expenses/${expenseId}` : '/api/v1/expenses';
+  const method = expenseId ? 'PATCH' : 'POST';
+
+  const res = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ ...data, status: 'draft' }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message ?? `Save failed with status ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export function useExpenseAutosave({
+  expenseId,
+  debounceMs = 1500,
+  onSaveSuccess,
+  onSaveError,
+}: AutosaveOptions = {}): AutosaveResult {
+  const [saveStatus, setSaveStatus]   = useState<SaveStatus>('idle');
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingData = useRef<Record<string, unknown> | null>(null);
+  const isSaving    = useRef(false);
+
+  const doSave = useCallback(async (data: Record<string, unknown>) => {
+    if (isSaving.current) {
+      pendingData.current = data;
+      return;
+    }
+
+    isSaving.current = true;
+    setSaveStatus('saving');
+
+    try {
+      const result = await saveDraft(expenseId, data);
+      setSaveStatus('saved');
+      setLastSavedAt(new Date());
+      onSaveSuccess?.(result);
+    } catch (err) {
+      setSaveStatus('error');
+      onSaveError?.(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      isSaving.current = false;
+
+      if (pendingData.current) {
+        const next = pendingData.current;
+        pendingData.current = null;
+        doSave(next);
+      }
+    }
+  }, [expenseId, onSaveSuccess, onSaveError]);
+
+  const triggerSave = useCallback((data: Record<string, unknown>) => {
+    setSaveStatus('idle');
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => doSave(data), debounceMs);
+  }, [doSave, debounceMs]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  return { saveStatus, lastSavedAt, triggerSave };
+}


### PR DESCRIPTION
## Summary

- Add `useExpenseAutosave` hook — debounced (1.5s default) PATCH/POST for draft expense data
  - Creates new expense via POST when no `expenseId` yet, updates via PATCH thereafter
  - Queues concurrent saves: if a save is in flight when another triggers, the latest data saves immediately after
  - Returns `saveStatus` (`idle` | `saving` | `saved` | `error`) and `lastSavedAt`
- Add `AutosaveIndicator.tsx` — compact status chip:
  - Animated yellow dot while saving
  - Green checkmark + timestamp on success
  - Red warning icon on error
- Cleanup: timer cleared on component unmount

## Test plan
- [ ] Field change triggers save after 1.5s debounce (not immediately)
- [ ] Rapid typing only fires one save (debounce collapses multiple changes)
- [ ] Network error shows red "Save failed" indicator
- [ ] `lastSavedAt` updates with correct time after each successful save
- [ ] Hook creates a new expense (POST) when `expenseId` is undefined

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_