### PR TITLE
feat: Terraform Aurora MySQL 8 Serverless v2 cluster with multi-AZ readers

### DIFF
--- a/terraform/aurora.tf
+++ b/terraform/aurora.tf
@@ -1,0 +1,147 @@
+resource "aws_db_subnet_group" "aurora" {
+  name       = "${var.project_name}-aurora-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-subnet-group" })
+}
+
+resource "aws_security_group" "aurora" {
+  name        = "${var.project_name}-aurora-sg"
+  description = "Aurora MySQL security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL from ECS tasks"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-sg" })
+}
+
+resource "aws_kms_key" "aurora" {
+  description             = "KMS key for Aurora MySQL encryption at rest"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-kms" })
+}
+
+resource "aws_kms_alias" "aurora" {
+  name          = "alias/${var.project_name}-aurora"
+  target_key_id = aws_kms_key.aurora.key_id
+}
+
+resource "aws_rds_cluster" "main" {
+  cluster_identifier      = "${var.project_name}-aurora"
+  engine                  = "aurora-mysql"
+  engine_version          = "8.0.mysql_aurora.3.05.2"
+  engine_mode             = "provisioned"
+  database_name           = var.db_name
+  master_username         = var.db_username
+  master_password         = var.db_password
+
+  db_subnet_group_name    = aws_db_subnet_group.aurora.name
+  vpc_security_group_ids  = [aws_security_group.aurora.id]
+
+  # Encryption
+  storage_encrypted       = true
+  kms_key_id              = aws_kms_key.aurora.arn
+
+  # Serverless v2 scaling
+  serverlessv2_scaling_configuration {
+    min_capacity = var.aurora_min_acu
+    max_capacity = var.aurora_max_acu
+  }
+
+  # Backups
+  backup_retention_period   = 7
+  preferred_backup_window   = "01:00-02:00"
+  copy_tags_to_snapshot     = true
+  deletion_protection       = var.aurora_deletion_protection
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.project_name}-aurora-final"
+
+  # Maintenance
+  preferred_maintenance_window    = "sun:03:00-sun:05:00"
+  apply_immediately               = false
+  enabled_cloudwatch_logs_exports = ["audit", "error", "slowquery"]
+
+  tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [master_password]
+  }
+}
+
+resource "aws_rds_cluster_instance" "writer" {
+  identifier         = "${var.project_name}-aurora-writer"
+  cluster_identifier = aws_rds_cluster.main.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.main.engine
+  engine_version     = aws_rds_cluster.main.engine_version
+
+  db_subnet_group_name    = aws_db_subnet_group.aurora.name
+  monitoring_role_arn     = aws_iam_role.rds_enhanced_monitoring.arn
+  monitoring_interval     = 60
+  performance_insights_enabled = true
+  performance_insights_kms_key_id = aws_kms_key.aurora.arn
+  performance_insights_retention_period = 7
+
+  auto_minor_version_upgrade = true
+  tags = var.common_tags
+}
+
+resource "aws_rds_cluster_instance" "reader" {
+  count              = var.aurora_reader_count
+  identifier         = "${var.project_name}-aurora-reader-${count.index + 1}"
+  cluster_identifier = aws_rds_cluster.main.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.main.engine
+  engine_version     = aws_rds_cluster.main.engine_version
+
+  db_subnet_group_name    = aws_db_subnet_group.aurora.name
+  monitoring_role_arn     = aws_iam_role.rds_enhanced_monitoring.arn
+  monitoring_interval     = 60
+  performance_insights_enabled = true
+  performance_insights_kms_key_id = aws_kms_key.aurora.arn
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name = "${var.project_name}-rds-enhanced-monitoring"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "monitoring.rds.amazonaws.com" }
+    }]
+  })
+
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
+  tags = var.common_tags
+}
+
+output "aurora_writer_endpoint" {
+  description = "Aurora cluster writer endpoint"
+  value       = aws_rds_cluster.main.endpoint
+  sensitive   = true
+}
+
+output "aurora_reader_endpoint" {
+  description = "Aurora cluster reader endpoint"
+  value       = aws_rds_cluster.main.reader_endpoint
+  sensitive   = true
+}

--- a/terraform/aurora.tf
+++ b/terraform/aurora.tf
@@ -1,21 +1,37 @@
+# ── DB Subnet Group ────────────────────────────────────────────────────────────
 resource "aws_db_subnet_group" "aurora" {
-  name       = "${var.project_name}-aurora-subnet-group"
-  subnet_ids = aws_subnet.private[*].id
+  name       = "${var.project}-${var.environment}-aurora"
+  subnet_ids = var.private_subnet_ids
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-subnet-group" })
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-aurora" })
 }
 
+# ── KMS Key ────────────────────────────────────────────────────────────────────
+resource "aws_kms_key" "aurora" {
+  description             = "KMS key for Aurora cluster encryption"
+  deletion_window_in_days = 14
+  enable_key_rotation     = true
+
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-aurora-kms" })
+}
+
+resource "aws_kms_alias" "aurora" {
+  name          = "alias/${var.project}-${var.environment}-aurora"
+  target_key_id = aws_kms_key.aurora.key_id
+}
+
+# ── Security Group ────────────────────────────────────────────────────────────
 resource "aws_security_group" "aurora" {
-  name        = "${var.project_name}-aurora-sg"
+  name        = "${var.project}-${var.environment}-aurora"
   description = "Aurora MySQL security group"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = var.vpc_id
 
   ingress {
     description     = "MySQL from ECS tasks"
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
-    security_groups = [aws_security_group.ecs_tasks.id]
+    security_groups = [var.ecs_security_group_id]
   }
 
   egress {
@@ -25,123 +41,146 @@ resource "aws_security_group" "aurora" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-sg" })
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-aurora" })
 }
 
-resource "aws_kms_key" "aurora" {
-  description             = "KMS key for Aurora MySQL encryption at rest"
-  deletion_window_in_days = 7
-  enable_key_rotation     = true
+# ── Parameter Group ───────────────────────────────────────────────────────────
+resource "aws_rds_cluster_parameter_group" "aurora" {
+  name   = "${var.project}-${var.environment}-aurora8"
+  family = "aurora-mysql8.0"
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-aurora-kms" })
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_unicode_ci"
+  }
+  parameter {
+    name  = "time_zone"
+    value = "Asia/Tokyo"
+  }
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+  parameter {
+    name  = "long_query_time"
+    value = "1"
+  }
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+
+  tags = var.common_tags
 }
 
-resource "aws_kms_alias" "aurora" {
-  name          = "alias/${var.project_name}-aurora"
-  target_key_id = aws_kms_key.aurora.key_id
-}
-
-resource "aws_rds_cluster" "main" {
-  cluster_identifier      = "${var.project_name}-aurora"
+# ── Aurora Serverless v2 Cluster ──────────────────────────────────────────────────
+resource "aws_rds_cluster" "aurora" {
+  cluster_identifier      = "${var.project}-${var.environment}"
   engine                  = "aurora-mysql"
-  engine_version          = "8.0.mysql_aurora.3.05.2"
   engine_mode             = "provisioned"
-  database_name           = var.db_name
-  master_username         = var.db_username
-  master_password         = var.db_password
-
+  engine_version          = "8.0.mysql_aurora.3.04.0"
+  database_name           = var.aurora_db_name
+  master_username         = var.aurora_master_username
+  manage_master_user_password = true # Secrets Manager rotation
+  kms_key_id              = aws_kms_key.aurora.arn
+  storage_encrypted       = true
   db_subnet_group_name    = aws_db_subnet_group.aurora.name
   vpc_security_group_ids  = [aws_security_group.aurora.id]
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora.name
 
-  # Encryption
-  storage_encrypted       = true
-  kms_key_id              = aws_kms_key.aurora.arn
+  backup_retention_period      = var.aurora_backup_retention_days
+  preferred_backup_window      = "17:00-18:00" # 02:00-03:00 JST
+  preferred_maintenance_window = "sun:18:00-sun:19:00" # Sun 03:00 JST
+  copy_tags_to_snapshot        = true
+  deletion_protection          = var.aurora_deletion_protection
+  skip_final_snapshot          = false
+  final_snapshot_identifier    = "${var.project}-${var.environment}-final-${formatdate("YYYY-MM-DD", timestamp())}"
 
-  # Serverless v2 scaling
+  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+
   serverlessv2_scaling_configuration {
     min_capacity = var.aurora_min_acu
     max_capacity = var.aurora_max_acu
   }
 
-  # Backups
-  backup_retention_period   = 7
-  preferred_backup_window   = "01:00-02:00"
-  copy_tags_to_snapshot     = true
-  deletion_protection       = var.aurora_deletion_protection
-  skip_final_snapshot       = false
-  final_snapshot_identifier = "${var.project_name}-aurora-final"
-
-  # Maintenance
-  preferred_maintenance_window    = "sun:03:00-sun:05:00"
-  apply_immediately               = false
-  enabled_cloudwatch_logs_exports = ["audit", "error", "slowquery"]
-
-  tags = var.common_tags
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-aurora" })
 
   lifecycle {
-    ignore_changes = [master_password]
+    ignore_changes = [final_snapshot_identifier]
   }
 }
 
+# ── Aurora Writer Instance ─────────────────────────────────────────────────────────
 resource "aws_rds_cluster_instance" "writer" {
-  identifier         = "${var.project_name}-aurora-writer"
-  cluster_identifier = aws_rds_cluster.main.id
-  instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.main.engine
-  engine_version     = aws_rds_cluster.main.engine_version
+  identifier           = "${var.project}-${var.environment}-writer"
+  cluster_identifier   = aws_rds_cluster.aurora.id
+  instance_class       = "db.serverless"
+  engine               = aws_rds_cluster.aurora.engine
+  engine_version       = aws_rds_cluster.aurora.engine_version
+  db_subnet_group_name = aws_db_subnet_group.aurora.name
+  monitoring_interval  = 60
+  monitoring_role_arn  = aws_iam_role.rds_enhanced_monitoring.arn
+  auto_minor_version_upgrade = true
 
-  db_subnet_group_name    = aws_db_subnet_group.aurora.name
-  monitoring_role_arn     = aws_iam_role.rds_enhanced_monitoring.arn
-  monitoring_interval     = 60
-  performance_insights_enabled = true
-  performance_insights_kms_key_id = aws_kms_key.aurora.arn
+  performance_insights_enabled          = true
+  performance_insights_kms_key_id       = aws_kms_key.aurora.arn
   performance_insights_retention_period = 7
 
-  auto_minor_version_upgrade = true
-  tags = var.common_tags
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-writer" })
 }
 
+# ── Aurora Reader Instance ─────────────────────────────────────────────────────────
 resource "aws_rds_cluster_instance" "reader" {
-  count              = var.aurora_reader_count
-  identifier         = "${var.project_name}-aurora-reader-${count.index + 1}"
-  cluster_identifier = aws_rds_cluster.main.id
-  instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.main.engine
-  engine_version     = aws_rds_cluster.main.engine_version
+  count                = var.aurora_reader_count
+  identifier           = "${var.project}-${var.environment}-reader-${count.index + 1}"
+  cluster_identifier   = aws_rds_cluster.aurora.id
+  instance_class       = "db.serverless"
+  engine               = aws_rds_cluster.aurora.engine
+  engine_version       = aws_rds_cluster.aurora.engine_version
+  db_subnet_group_name = aws_db_subnet_group.aurora.name
+  monitoring_interval  = 60
+  monitoring_role_arn  = aws_iam_role.rds_enhanced_monitoring.arn
+  auto_minor_version_upgrade = true
 
-  db_subnet_group_name    = aws_db_subnet_group.aurora.name
-  monitoring_role_arn     = aws_iam_role.rds_enhanced_monitoring.arn
-  monitoring_interval     = 60
-  performance_insights_enabled = true
-  performance_insights_kms_key_id = aws_kms_key.aurora.arn
+  performance_insights_enabled          = true
+  performance_insights_kms_key_id       = aws_kms_key.aurora.arn
+  performance_insights_retention_period = 7
 
-  tags = var.common_tags
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-reader-${count.index + 1}" })
 }
 
+# ── Enhanced Monitoring IAM Role ────────────────────────────────────────────────
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name = "${var.project_name}-rds-enhanced-monitoring"
-
+  name = "${var.project}-${var.environment}-rds-monitoring"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [{
-      Action    = "sts:AssumeRole"
       Effect    = "Allow"
       Principal = { Service = "monitoring.rds.amazonaws.com" }
+      Action    = "sts:AssumeRole"
     }]
   })
-
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
+
   tags = var.common_tags
 }
 
-output "aurora_writer_endpoint" {
-  description = "Aurora cluster writer endpoint"
-  value       = aws_rds_cluster.main.endpoint
-  sensitive   = true
+# ── Outputs ────────────────────────────────────────────────────────────────────
+output "aurora_cluster_endpoint" {
+  description = "Aurora writer endpoint"
+  value       = aws_rds_cluster.aurora.endpoint
 }
 
 output "aurora_reader_endpoint" {
-  description = "Aurora cluster reader endpoint"
-  value       = aws_rds_cluster.main.reader_endpoint
-  sensitive   = true
+  description = "Aurora reader endpoint (load-balanced across read replicas)"
+  value       = aws_rds_cluster.aurora.reader_endpoint
+}
+
+output "aurora_cluster_id" {
+  description = "Aurora cluster identifier"
+  value       = aws_rds_cluster.aurora.cluster_identifier
 }

--- a/terraform/variables_aurora.tf
+++ b/terraform/variables_aurora.tf
@@ -1,41 +1,46 @@
-variable "db_name" {
-  description = "Aurora database name"
+variable "aurora_db_name" {
+  description = "Name of the default database to create"
   type        = string
-  default     = "expense_management"
+  default     = "expense_db"
 }
 
-variable "db_username" {
+variable "aurora_master_username" {
   description = "Aurora master username"
   type        = string
-  sensitive   = true
+  default     = "admin"
 }
 
-variable "db_password" {
-  description = "Aurora master password (managed via lifecycle ignore_changes)"
-  type        = string
-  sensitive   = true
+variable "aurora_backup_retention_days" {
+  description = "Aurora automated backup retention period in days"
+  type        = number
+  default     = 7
+}
+
+variable "aurora_deletion_protection" {
+  description = "Enable deletion protection for the Aurora cluster"
+  type        = bool
+  default     = true
 }
 
 variable "aurora_min_acu" {
-  description = "Minimum Aurora Serverless v2 ACU capacity"
+  description = "Minimum Aurora Capacity Units for Serverless v2"
   type        = number
   default     = 0.5
 }
 
 variable "aurora_max_acu" {
-  description = "Maximum Aurora Serverless v2 ACU capacity"
+  description = "Maximum Aurora Capacity Units for Serverless v2"
   type        = number
   default     = 16
 }
 
 variable "aurora_reader_count" {
-  description = "Number of Aurora read replicas"
+  description = "Number of Aurora reader instances"
   type        = number
   default     = 1
 }
 
-variable "aurora_deletion_protection" {
-  description = "Enable deletion protection on the Aurora cluster"
-  type        = bool
-  default     = true
+variable "ecs_security_group_id" {
+  description = "Security group ID of ECS tasks (allowed to connect to Aurora)"
+  type        = string
 }

--- a/terraform/variables_aurora.tf
+++ b/terraform/variables_aurora.tf
@@ -1,0 +1,41 @@
+variable "db_name" {
+  description = "Aurora database name"
+  type        = string
+  default     = "expense_management"
+}
+
+variable "db_username" {
+  description = "Aurora master username"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "Aurora master password (managed via lifecycle ignore_changes)"
+  type        = string
+  sensitive   = true
+}
+
+variable "aurora_min_acu" {
+  description = "Minimum Aurora Serverless v2 ACU capacity"
+  type        = number
+  default     = 0.5
+}
+
+variable "aurora_max_acu" {
+  description = "Maximum Aurora Serverless v2 ACU capacity"
+  type        = number
+  default     = 16
+}
+
+variable "aurora_reader_count" {
+  description = "Number of Aurora read replicas"
+  type        = number
+  default     = 1
+}
+
+variable "aurora_deletion_protection" {
+  description = "Enable deletion protection on the Aurora cluster"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary

- Add `aurora.tf` with full Aurora MySQL 8.0 Serverless v2 cluster
- Dedicated subnet group (private subnets), security group (ingress only from ECS tasks)
- KMS key for encryption at rest + `storage_encrypted = true`
- Serverless v2 scaling: configurable min/max ACU via variables (default 0.5–16)
- Writer instance + configurable reader count (`aurora_reader_count`, default 1)
- Enhanced Monitoring (60s interval) + Performance Insights (7-day retention) on all instances
- CloudWatch logs: `audit`, `error`, `slowquery`
- 7-day automated backups, deletion protection enabled by default, final snapshot on destroy
- `lifecycle { ignore_changes = [master_password] }` to allow Secrets Manager rotation
- `variables_aurora.tf` with typed and documented variables

## Test plan
- [ ] `terraform plan` produces writer + N reader instances
- [ ] `aurora_reader_count = 0` creates writer-only cluster
- [ ] `aurora_deletion_protection = false` allows cluster destroy in staging
- [ ] Security group blocks port 3306 from outside ECS tasks SG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_