### PR TITLE
feat: k6 load test scenarios with smoke, load, and stress configurations

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,38 @@
+# Load Testing with k6
+
+## Prerequisites
+
+```bash
+brew install k6   # macOS
+# or
+winget install k6  # Windows
+```
+
+## Running tests
+
+```bash
+# Smoke test (1 VU, 1 min)
+BASE_URL=https://staging.example.com/api/v1 \
+TEST_EMAIL=loadtest@example.com \
+TEST_PASSWORD=secret \
+k6 run --env BASE_URL=$BASE_URL tests/load/expense-api.k6.js \
+  --scenario smoke
+
+# Load test with HTML report
+k6 run tests/load/expense-api.k6.js \
+  --scenario load \
+  --out json=results/load-$(date +%Y%m%d).json
+
+# Stress test
+k6 run tests/load/expense-api.k6.js --scenario stress
+```
+
+## Thresholds
+
+| Metric | Threshold |
+|--------|----------|
+| p(95) response time | < 500ms |
+| p(99) response time | < 1000ms |
+| Error rate | < 1% |
+| Expense create p(95) | < 600ms |
+| List p(95) | < 300ms |

--- a/tests/load/expense-api.k6.js
+++ b/tests/load/expense-api.k6.js
@@ -1,0 +1,138 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const errorRate    = new Rate('error_rate');
+const expenseCreateDuration = new Trend('expense_create_duration', true);
+const listDuration = new Trend('expense_list_duration', true);
+const authFailures = new Counter('auth_failures');
+
+export const options = {
+  scenarios: {
+    // Smoke test: 1 user, 1 minute
+    smoke: {
+      executor: 'constant-vus',
+      vus: 1,
+      duration: '1m',
+      tags: { scenario: 'smoke' },
+    },
+    // Load test: ramp up to 50 users over 5 min, hold 10 min, ramp down
+    load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '5m', target: 50 },
+        { duration: '10m', target: 50 },
+        { duration: '5m', target: 0 },
+      ],
+      tags: { scenario: 'load' },
+    },
+    // Stress test: push to 200 users
+    stress: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 100 },
+        { duration: '5m', target: 200 },
+        { duration: '2m', target: 0 },
+      ],
+      tags: { scenario: 'stress' },
+    },
+  },
+  thresholds: {
+    http_req_duration:         ['p(95)<500', 'p(99)<1000'],
+    http_req_failed:           ['rate<0.01'],
+    error_rate:                ['rate<0.05'],
+    expense_create_duration:   ['p(95)<600'],
+    expense_list_duration:     ['p(95)<300'],
+  },
+};
+
+const BASE_URL  = __ENV.BASE_URL  || 'http://localhost:8000/api/v1';
+const API_TOKEN = __ENV.API_TOKEN || '';
+
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  Authorization: `Bearer ${API_TOKEN}`,
+};
+
+export function setup() {
+  // Authenticate and return token for use in default function
+  const loginRes = http.post(
+    `${BASE_URL}/auth/login`,
+    JSON.stringify({ email: __ENV.TEST_EMAIL, password: __ENV.TEST_PASSWORD }),
+    { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } }
+  );
+
+  check(loginRes, { 'login succeeded': r => r.status === 200 }) ||
+    authFailures.add(1);
+
+  const token = loginRes.json('token');
+  return { token };
+}
+
+export default function (data) {
+  const authHeaders = {
+    ...headers,
+    Authorization: `Bearer ${data.token}`,
+  };
+
+  group('List expenses', () => {
+    const start = Date.now();
+    const res = http.get(`${BASE_URL}/expenses?per_page=20`, { headers: authHeaders });
+    listDuration.add(Date.now() - start);
+
+    const ok = check(res, {
+      'list status 200':       r => r.status === 200,
+      'list has data array':   r => Array.isArray(r.json('data')),
+    });
+    errorRate.add(!ok);
+  });
+
+  sleep(0.5);
+
+  group('Create expense', () => {
+    const payload = JSON.stringify({
+      title:        `Load test expense ${Date.now()}`,
+      amount:       Math.floor(Math.random() * 50000) + 1000,
+      currency:     'JPY',
+      category_id:  1,
+      expense_date: '2024-06-15',
+    });
+
+    const start = Date.now();
+    const res = http.post(`${BASE_URL}/expenses`, payload, { headers: authHeaders });
+    expenseCreateDuration.add(Date.now() - start);
+
+    const ok = check(res, {
+      'create status 201': r => r.status === 201,
+      'has id':            r => r.json('id') > 0,
+      'status is draft':   r => r.json('status') === 'draft',
+    });
+    errorRate.add(!ok);
+
+    if (ok) {
+      const expenseId = res.json('id');
+      sleep(0.3);
+
+      group('Get expense detail', () => {
+        const detailRes = http.get(`${BASE_URL}/expenses/${expenseId}`, { headers: authHeaders });
+        check(detailRes, { 'detail status 200': r => r.status === 200 });
+      });
+    }
+  });
+
+  sleep(1);
+
+  group('Report monthly', () => {
+    const res = http.get(`${BASE_URL}/reports/monthly?year=2024`, { headers: authHeaders });
+    check(res, {
+      'report status 200':    r => r.status === 200,
+      'has 12 months':        r => r.json('months') && r.json('months').length === 12,
+    });
+  });
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary

- Add `tests/load/expense-api.k6.js` — k6 load test with 3 scenarios:
  - **Smoke**: 1 VU, 1 minute — baseline sanity check
  - **Load**: ramp to 50 VUs over 5 min, hold 10 min, ramp down
  - **Stress**: ramp to 200 VUs — find breaking point
- Custom metrics: `error_rate`, `expense_create_duration`, `expense_list_duration`, `auth_failures`
- Thresholds: p95 < 500ms, p99 < 1s, error rate < 1%
- Test groups: List, Create, Detail, Monthly report
- OIDC/token-based auth via `setup()` function
- Add `tests/load/README.md` with install and run instructions

## Test plan
- [ ] `k6 run --scenario smoke tests/load/expense-api.k6.js` passes all thresholds
- [ ] All checks pass for list (200 + data array) and create (201 + id + draft status)
- [ ] `BASE_URL` and `TEST_EMAIL`/`TEST_PASSWORD` env vars configurable
- [ ] Results exportable to JSON with `--out json=results/...`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_