### PR TITLE
feat: Terraform GitHub Actions OIDC IAM role for keyless CI/CD

### DIFF
--- a/terraform/github_actions_oidc.tf
+++ b/terraform/github_actions_oidc.tf
@@ -1,0 +1,122 @@
+# GitHub Actions OIDC — keyless authentication for CI/CD pipelines
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_github_oidc_provider ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = var.common_tags
+}
+
+locals {
+  oidc_provider_arn = var.create_github_oidc_provider
+    ? aws_iam_openid_connect_provider.github[0].arn
+    : data.aws_iam_openid_connect_provider.github.arn
+}
+
+resource "aws_iam_role" "github_actions" {
+  name = "${var.project_name}-github-actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Federated = local.oidc_provider_arn }
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              for repo in var.github_repos :
+              "repo:${repo}:*"
+            ]
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+# ECR: push images from CI
+resource "aws_iam_role_policy" "github_actions_ecr" {
+  name = "ecr-push"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
+          "ecr:DescribeImages",
+        ]
+        Resource = [
+          "arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/${var.project_name}-*"
+        ]
+      }
+    ]
+  })
+}
+
+# ECS: deploy new task definition revision
+resource "aws_iam_role_policy" "github_actions_ecs" {
+  name = "ecs-deploy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:RegisterTaskDefinition",
+          "ecs:UpdateService",
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "ecs:ListTaskDefinitions",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["iam:PassRole"]
+        Resource = [
+          aws_iam_role.ecs_task_execution.arn,
+          aws_iam_role.ecs_task_role.arn,
+        ]
+      }
+    ]
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+output "github_actions_role_arn" {
+  description = "IAM role ARN for GitHub Actions OIDC — use as AWS_ROLE_ARN in workflow"
+  value       = aws_iam_role.github_actions.arn
+}

--- a/terraform/variables_github_oidc.tf
+++ b/terraform/variables_github_oidc.tf
@@ -1,0 +1,11 @@
+variable "github_repos" {
+  description = "GitHub repos allowed to assume the Actions role (format: org/repo)"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_github_oidc_provider" {
+  description = "Create the OIDC provider (false if already exists in the account)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary

- Add `github_actions_oidc.tf` — OIDC provider + IAM role for keyless GitHub Actions auth
- Condition: only repos matching `var.github_repos` (format `org/repo`) can assume the role
- Double condition: `sub` (repo filter) + `aud` = `sts.amazonaws.com`
- `create_github_oidc_provider` variable: set `false` if provider already exists in the account
- ECR policy: `GetAuthorizationToken` (global) + push/pull on `${project_name}-*` repos
- ECS policy: `RegisterTaskDefinition`, `UpdateService`, `DescribeServices` + `iam:PassRole` for task roles
- Outputs `github_actions_role_arn` for use as `AWS_ROLE_ARN` in GitHub workflow `permissions: id-token: write`

## Test plan
- [ ] `terraform plan` shows role with correct OIDC condition
- [ ] `sub` condition uses `StringLike` (supports wildcard branch patterns)
- [ ] ECR policy scoped to `${project_name}-*` repos, not all ECR
- [ ] `iam:PassRole` limited to ECS task execution + task role ARNs only

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_