### PR TITLE
feat: backend expense line items with sync endpoint and auto-total

### DIFF
--- a/app/Http/Controllers/Api/ExpenseLineItemController.php
+++ b/app/Http/Controllers/Api/ExpenseLineItemController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Expense;
+use App\Models\ExpenseLineItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ExpenseLineItemController extends Controller
+{
+    public function index(Expense $expense): JsonResponse
+    {
+        $this->authorizeExpense($expense);
+
+        return response()->json(
+            $expense->lineItems()->orderBy('sort_order')->get()
+        );
+    }
+
+    public function sync(Request $request, Expense $expense): JsonResponse
+    {
+        $this->authorizeExpense($expense);
+        abort_if($expense->status !== 'draft', 403, 'Cannot modify line items on a non-draft expense.');
+
+        $data = $request->validate([
+            'items'                    => 'required|array|min:1|max:100',
+            'items.*.description'      => 'required|string|max:500',
+            'items.*.unit_price'       => 'required|numeric|min:0',
+            'items.*.quantity'         => 'nullable|numeric|min:0.001|max:9999',
+            'items.*.unit'             => 'nullable|string|max:50',
+            'items.*.sort_order'       => 'nullable|integer|min:0',
+        ]);
+
+        DB::transaction(function () use ($expense, $data) {
+            $expense->lineItems()->delete();
+
+            $now  = now();
+            $rows = array_map(fn($item, $i) => [
+                'expense_id'  => $expense->id,
+                'description' => $item['description'],
+                'unit_price'  => $item['unit_price'],
+                'quantity'    => $item['quantity'] ?? 1,
+                'unit'        => $item['unit'] ?? null,
+                'sort_order'  => $item['sort_order'] ?? $i,
+                'created_at'  => $now,
+                'updated_at'  => $now,
+            ], $data['items'], array_keys($data['items']));
+
+            ExpenseLineItem::insert($rows);
+
+            // Sync expense total amount to sum of line items
+            $total = array_sum(array_map(
+                fn($item) => ($item['unit_price'] * ($item['quantity'] ?? 1)),
+                $data['items']
+            ));
+            $expense->update(['amount' => $total]);
+        });
+
+        return response()->json([
+            'items' => $expense->lineItems()->orderBy('sort_order')->get(),
+            'total' => $expense->fresh()->amount,
+        ]);
+    }
+
+    private function authorizeExpense(Expense $expense): void
+    {
+        abort_unless($expense->tenant_id === Auth::user()->tenant_id, 404);
+    }
+}

--- a/app/Models/ExpenseLineItem.php
+++ b/app/Models/ExpenseLineItem.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExpenseLineItem extends Model
+{
+    protected $fillable = [
+        'expense_id',
+        'description',
+        'unit_price',
+        'quantity',
+        'unit',
+        'sort_order',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'unit_price' => 'decimal:2',
+        'quantity'   => 'decimal:3',
+        'amount'     => 'decimal:2',
+        'sort_order' => 'integer',
+        'metadata'   => 'array',
+    ];
+
+    public function expense(): BelongsTo
+    {
+        return $this->belongsTo(Expense::class);
+    }
+}

--- a/database/migrations/2024_01_15_000018_create_expense_line_items_table.php
+++ b/database/migrations/2024_01_15_000018_create_expense_line_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expense_line_items', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('expense_id')->index();
+            $table->string('description');
+            $table->decimal('unit_price', 12, 2);
+            $table->decimal('quantity', 8, 3)->default(1);
+            $table->decimal('amount', 12, 2)->storedAs('unit_price * quantity');
+            $table->string('unit')->nullable();
+            $table->unsignedTinyInteger('sort_order')->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['expense_id', 'sort_order']);
+            $table->foreign('expense_id')->references('id')->on('expenses')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_line_items');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `expense_line_items` migration — `unit_price * quantity` stored computed `amount` column
- Add `ExpenseLineItem` model with decimal casts
- Add `ExpenseLineItemController` with 2 endpoints:
  - `GET /api/v1/expenses/{id}/line-items` — list items in sort order
  - `PUT /api/v1/expenses/{id}/line-items` — full sync (delete-all + insert) in a transaction
- Sync also updates `expenses.amount` to the sum of all line item amounts
- Only draft expenses can have line items modified (403 on pending/approved)
- `cascadeOnDelete` on `expense_id` — items auto-removed when expense is deleted

## Test plan
- [ ] Sync with 3 items sets `expense.amount` to their sum
- [ ] Subsequent sync replaces all previous items
- [ ] `amount` column is computed server-side (not sent by client)
- [ ] Attempting sync on `pending` expense returns 403
- [ ] Cross-tenant expense returns 404

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_