### PR TITLE
feat: React error boundary with fallback UI and backend error reporting

### DIFF
--- a/resources/js/components/ErrorBoundary.tsx
+++ b/resources/js/components/ErrorBoundary.tsx
@@ -1,0 +1,135 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+  resetKeys?: unknown[];
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorId: string | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, errorId: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return {
+      hasError: true,
+      error,
+      errorId: `err_${Math.random().toString(36).slice(2, 9)}`,
+    };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+
+    // Report to backend error tracker
+    fetch('/api/v1/client-errors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        error_id:   this.state.errorId,
+        message:    error.message,
+        stack:      error.stack,
+        component:  info.componentStack,
+        url:        window.location.href,
+        user_agent: navigator.userAgent,
+      }),
+    }).catch(() => undefined);
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    if (
+      this.state.hasError &&
+      prevProps.resetKeys !== this.props.resetKeys &&
+      this.props.resetKeys?.some((key, i) => key !== prevProps.resetKeys?.[i])
+    ) {
+      this.setState({ hasError: false, error: null, errorId: null });
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ hasError: false, error: null, errorId: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <DefaultErrorFallback
+          error={this.state.error}
+          errorId={this.state.errorId}
+          onReset={this.reset}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function DefaultErrorFallback({
+  error,
+  errorId,
+  onReset,
+}: {
+  error: Error | null;
+  errorId: string | null;
+  onReset: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center min-h-[300px] p-8 text-center"
+    >
+      <div className="w-16 h-16 mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+        <svg className="w-8 h-8 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        Something went wrong
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-1 max-w-sm">
+        {error?.message ?? 'An unexpected error occurred.'}
+      </p>
+      {errorId && (
+        <p className="text-xs text-gray-400 dark:text-gray-500 mb-6 font-mono">
+          Error ID: {errorId}
+        </p>
+      )}
+      <div className="flex gap-3">
+        <button
+          onClick={onReset}
+          className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          Reload page
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function withErrorBoundary<P extends object>(
+  Component: React.ComponentType<P>,
+  boundaryProps?: Omit<Props, 'children'>
+): React.FC<P> {
+  return function WrappedWithErrorBoundary(props: P) {
+    return (
+      <ErrorBoundary {...boundaryProps}>
+        <Component {...props} />
+      </ErrorBoundary>
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- Add `ErrorBoundary` class component using `getDerivedStateFromError` + `componentDidCatch`
- On error: reports to `POST /api/v1/client-errors` with message, stack, component tree, URL, user agent, and generated `errorId`
- `resetKeys` prop: resets boundary when any key changes (for route-based recovery)
- `DefaultErrorFallback`: shows error message, `errorId` for support, "Try again" (soft reset) and "Reload page" buttons
- `withErrorBoundary` HOC for wrapping individual components
- `fallback` prop for custom error UI

## Test plan
- [ ] Throwing component renders fallback, not white screen
- [ ] `errorId` appears in fallback and is sent to backend
- [ ] "Try again" resets `hasError` and re-renders children
- [ ] `resetKeys` change clears error state automatically
- [ ] `withErrorBoundary(MyComponent)` wraps without extra DOM nodes

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_