### PR TITLE
feat: useInfiniteScroll hook with IntersectionObserver and cursor pagination

### DIFF
--- a/resources/js/components/InfiniteScrollSentinel.tsx
+++ b/resources/js/components/InfiniteScrollSentinel.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface Props {
+  sentinelRef: React.RefObject<HTMLDivElement>;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean | undefined;
+}
+
+export default function InfiniteScrollSentinel({ sentinelRef, isFetchingNextPage, hasNextPage }: Props) {
+  return (
+    <div ref={sentinelRef} className="py-4 flex justify-center">
+      {isFetchingNextPage && (
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Loading more...
+        </div>
+      )}
+      {!hasNextPage && !isFetchingNextPage && (
+        <span className="text-xs text-gray-400 dark:text-gray-500">All items loaded</span>
+      )}
+    </div>
+  );
+}

--- a/resources/js/hooks/useInfiniteScroll.ts
+++ b/resources/js/hooks/useInfiniteScroll.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query';
+
+interface CursorPage<T> {
+  data: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+interface UseInfiniteScrollOptions<T> extends
+  Omit<UseInfiniteQueryOptions<CursorPage<T>, Error, CursorPage<T>, CursorPage<T>, string[], string | null>, 'queryFn' | 'getNextPageParam' | 'initialPageParam'> {
+  queryKey: string[];
+  fetcher: (cursor: string | null) => Promise<CursorPage<T>>;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export function useInfiniteScroll<T>({
+  queryKey,
+  fetcher,
+  rootMargin = '200px',
+  threshold = 0,
+  ...queryOptions
+}: UseInfiniteScrollOptions<T>) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const query = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => fetcher(pageParam ?? null),
+    getNextPageParam: (last) => last.has_more ? last.next_cursor : undefined,
+    initialPageParam: null as string | null,
+    ...queryOptions,
+  } as UseInfiniteQueryOptions<CursorPage<T>, Error, CursorPage<T>, CursorPage<T>, string[], string | null>);
+
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0].isIntersecting) loadMore(); },
+      { rootMargin, threshold }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore, rootMargin, threshold]);
+
+  const allItems = query.data?.pages.flatMap(p => p.data) ?? [];
+
+  return {
+    ...query,
+    items: allItems,
+    sentinelRef,
+    loadMore,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `useInfiniteScroll` hook wrapping TanStack Query `useInfiniteQuery`
  - Cursor-based pagination: `fetcher(cursor: string | null)` → `{ data, next_cursor, has_more }`
  - `sentinelRef` — attach to a bottom-of-list div; `IntersectionObserver` triggers `fetchNextPage` when visible
  - Configurable `rootMargin` (default 200px) and `threshold`
  - Returns `items` (flattened all pages), `sentinelRef`, and all `useInfiniteQuery` state
- Add `InfiniteScrollSentinel` component — shows spinner while loading next page, "All items loaded" when exhausted

## Test plan
- [ ] First page loads on mount
- [ ] Scrolling sentinel into viewport triggers next page fetch
- [ ] `items` is flat array of all fetched pages combined
- [ ] `has_more: false` stops further fetching
- [ ] Spinner shows during `isFetchingNextPage`; "All items loaded" shows after

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_