### PR TITLE
feat: HMAC-SHA256 webhook signature verification middleware

### DIFF
--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class WebhookController extends Controller
+{
+    public function handlePaymentProvider(Request $request): JsonResponse
+    {
+        $payload = $request->json()->all();
+        $event   = $payload['event'] ?? null;
+
+        Log::info('Webhook received', ['event' => $event]);
+
+        match ($event) {
+            'payment.completed' => $this->markExpensePaid($payload),
+            'payment.failed'    => $this->markExpensePaymentFailed($payload),
+            default             => Log::warning('Unknown webhook event', ['event' => $event]),
+        };
+
+        return response()->json(['received' => true]);
+    }
+
+    private function markExpensePaid(array $payload): void
+    {
+        $expenseId = $payload['metadata']['expense_id'] ?? null;
+        if (!$expenseId) {
+            return;
+        }
+
+        Expense::where('id', $expenseId)
+            ->where('status', 'approved')
+            ->update(['status' => 'paid', 'paid_at' => now()]);
+    }
+
+    private function markExpensePaymentFailed(array $payload): void
+    {
+        $expenseId = $payload['metadata']['expense_id'] ?? null;
+        if (!$expenseId) {
+            return;
+        }
+
+        Expense::where('id', $expenseId)
+            ->update(['payment_error' => $payload['error']['message'] ?? 'Unknown error']);
+    }
+}

--- a/app/Http/Middleware/VerifyWebhookSignature.php
+++ b/app/Http/Middleware/VerifyWebhookSignature.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyWebhookSignature
+{
+    public function handle(Request $request, Closure $next, string $secretKey = 'webhook'): Response
+    {
+        $secret = config("services.webhooks.{$secretKey}_secret");
+
+        if (empty($secret)) {
+            abort(500, 'Webhook secret not configured');
+        }
+
+        $signature = $request->header('X-Webhook-Signature');
+
+        if (empty($signature)) {
+            abort(401, 'Missing webhook signature');
+        }
+
+        $payload = $request->getContent();
+        $expected = 'sha256=' . hash_hmac('sha256', $payload, $secret);
+
+        if (!hash_equals($expected, $signature)) {
+            abort(403, 'Invalid webhook signature');
+        }
+
+        $timestamp = $request->header('X-Webhook-Timestamp');
+        if ($timestamp && abs(time() - (int) $timestamp) > 300) {
+            abort(403, 'Webhook timestamp too old (replay attack prevention)');
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/WebhookSignatureTest.php
+++ b/tests/Feature/WebhookSignatureTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class WebhookSignatureTest extends TestCase
+{
+    private string $secret = 'test-webhook-secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.webhooks.payment_secret' => $this->secret]);
+    }
+
+    public function test_valid_signature_passes(): void
+    {
+        $payload   = json_encode(['event' => 'payment.completed', 'metadata' => ['expense_id' => 1]]);
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, $this->secret);
+
+        $response = $this->postJson(
+            '/api/webhooks/payment',
+            json_decode($payload, true),
+            ['X-Webhook-Signature' => $signature]
+        );
+
+        $response->assertStatus(200);
+    }
+
+    public function test_missing_signature_returns_401(): void
+    {
+        $this->postJson('/api/webhooks/payment', [])
+            ->assertStatus(401);
+    }
+
+    public function test_invalid_signature_returns_403(): void
+    {
+        $this->postJson(
+            '/api/webhooks/payment',
+            [],
+            ['X-Webhook-Signature' => 'sha256=invalidsig']
+        )->assertStatus(403);
+    }
+
+    public function test_stale_timestamp_returns_403(): void
+    {
+        $payload   = json_encode(['event' => 'ping']);
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, $this->secret);
+        $stale     = time() - 600;
+
+        $this->postJson(
+            '/api/webhooks/payment',
+            json_decode($payload, true),
+            [
+                'X-Webhook-Signature' => $signature,
+                'X-Webhook-Timestamp' => (string) $stale,
+            ]
+        )->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary

- `VerifyWebhookSignature` middleware validates `X-Webhook-Signature: sha256=<hmac>` header
- Replay-attack prevention: rejects requests with `X-Webhook-Timestamp` older than 5 minutes
- `WebhookController` handles `payment.completed` and `payment.failed` events from payment provider
- 4 feature tests covering: valid signature, missing signature (401), invalid signature (403), stale timestamp (403)

## Test plan
- [ ] `php artisan test tests/Feature/WebhookSignatureTest.php` — 4 green
- [ ] Register middleware in `bootstrap/app.php` route group for `/api/webhooks/*`
- [ ] Verify `hash_equals` prevents timing-attack on signature comparison

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_