### PR TITLE
feat: async CSV export job with S3 storage and email notification

### DIFF
--- a/app/Http/Controllers/Api/ExportController.php
+++ b/app/Http/Controllers/Api/ExportController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\ExportExpensesCsv;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class ExportController extends Controller
+{
+    public function exportExpenses(Request $request): JsonResponse
+    {
+        $request->validate([
+            'status' => 'nullable|in:draft,pending,approved,rejected,paid',
+            'from'   => 'nullable|date_format:Y-m-d',
+            'to'     => 'nullable|date_format:Y-m-d|after_or_equal:from',
+        ]);
+
+        $exportId = Str::uuid()->toString();
+
+        ExportExpensesCsv::dispatch(
+            tenantId:          $request->user()->tenant_id,
+            requestedByUserId: $request->user()->id,
+            filters:           $request->only('status', 'from', 'to'),
+            exportId:          $exportId,
+        )->onQueue('reports');
+
+        return response()->json([
+            'message'   => 'Export started. You will receive a notification when it is ready.',
+            'export_id' => $exportId,
+        ], 202);
+    }
+}

--- a/app/Jobs/ExportExpensesCsv.php
+++ b/app/Jobs/ExportExpensesCsv.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use League\Csv\Writer;
+use SplTempFileObject;
+
+class ExportExpensesCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries   = 3;
+    public int $timeout = 300;
+
+    public function __construct(
+        private readonly int    $tenantId,
+        private readonly int    $requestedByUserId,
+        private readonly array  $filters = [],
+        private readonly string $exportId = '',
+    ) {}
+
+    public function handle(): void
+    {
+        $csv = Writer::createFromFileObject(new SplTempFileObject());
+        $csv->insertOne([
+            'ID', 'Title', 'Amount', 'Currency', 'Category', 'Status',
+            'Submitted By', 'Submitted At', 'Approved At', 'Paid At', 'Description',
+        ]);
+
+        Expense::query()
+            ->where('tenant_id', $this->tenantId)
+            ->with(['user:id,name', 'category:id,name'])
+            ->when(isset($this->filters['status']), fn ($q) => $q->where('status', $this->filters['status']))
+            ->when(isset($this->filters['from']), fn ($q) => $q->whereDate('created_at', '>=', $this->filters['from']))
+            ->when(isset($this->filters['to']),   fn ($q) => $q->whereDate('created_at', '<=', $this->filters['to']))
+            ->orderBy('created_at', 'desc')
+            ->chunk(500, function ($expenses) use ($csv) {
+                foreach ($expenses as $expense) {
+                    $csv->insertOne([
+                        $expense->id,
+                        $expense->title,
+                        number_format($expense->amount / 100, 2),
+                        $expense->currency ?? 'JPY',
+                        $expense->category?->name ?? '',
+                        $expense->status,
+                        $expense->user?->name ?? '',
+                        $expense->created_at?->toDateString() ?? '',
+                        $expense->approved_at?->toDateString() ?? '',
+                        $expense->paid_at?->toDateString() ?? '',
+                        $expense->description ?? '',
+                    ]);
+                }
+            });
+
+        $path = "exports/tenant_{$this->tenantId}/expenses_{$this->exportId}.csv";
+        Storage::disk('s3')->put($path, $csv->toString(), [
+            'ContentType'        => 'text/csv; charset=UTF-8',
+            'ContentDisposition' => 'attachment; filename="expenses.csv"',
+            'ServerSideEncryption' => 'aws:kms',
+        ]);
+
+        // Notify the requesting user
+        $user = User::find($this->requestedByUserId);
+        if ($user) {
+            $presignedUrl = Storage::disk('s3')->temporaryUrl($path, now()->addMinutes(60));
+            $user->notify(new \App\Notifications\ExportReadyNotification($presignedUrl));
+        }
+    }
+}

--- a/app/Notifications/ExportReadyNotification.php
+++ b/app/Notifications/ExportReadyNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ExportReadyNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly string $downloadUrl) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your expense export is ready')
+            ->line('Your CSV export has been generated successfully.')
+            ->action('Download CSV', $this->downloadUrl)
+            ->line('This link will expire in 60 minutes.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type'         => 'export_ready',
+            'download_url' => $this->downloadUrl,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- `ExportExpensesCsv` queued job streams expenses in 500-row chunks via League CSV Writer
- Filters: status, from date, to date; tenant-scoped via `tenant_id`
- Stores to S3 with KMS encryption; generates 60-minute presigned URL
- `ExportReadyNotification` sends mail + database notification with download link
- `ExportController::exportExpenses` dispatches job to `reports` queue, returns 202

## Test plan
- [ ] POST `/api/exports/expenses` with valid filters → 202 + export_id
- [ ] Job runs and file appears in S3 at correct path
- [ ] Presigned URL accessible for 60 minutes then expires
- [ ] User receives email with download link

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_