### PR TITLE
feat: audit log model, migration, and query API with cursor pagination

### DIFF
--- a/app/Http/Controllers/Api/AuditLogController.php
+++ b/app/Http/Controllers/Api/AuditLogController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Traits\HasCursorPagination;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AuditLogController extends Controller
+{
+    use HasCursorPagination;
+
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'action'         => 'nullable|string|max:100',
+            'auditable_type' => 'nullable|string|max:100',
+            'auditable_id'   => 'nullable|integer',
+            'user_id'        => 'nullable|integer',
+            'from'           => 'nullable|date_format:Y-m-d',
+            'to'             => 'nullable|date_format:Y-m-d|after_or_equal:from',
+            'limit'          => 'nullable|integer|min:1|max:100',
+            'cursor'         => 'nullable|string',
+        ]);
+
+        $query = AuditLog::with('user:id,name,email')
+            ->forTenant($request->user()->tenant_id)
+            ->when($request->action,         fn ($q) => $q->where('action', $request->action))
+            ->when($request->auditable_type,  fn ($q) => $q->where('auditable_type', $request->auditable_type))
+            ->when($request->auditable_id,    fn ($q) => $q->where('auditable_id', $request->auditable_id))
+            ->when($request->user_id,         fn ($q) => $q->where('user_id', $request->user_id))
+            ->when($request->from,            fn ($q) => $q->whereDate('created_at', '>=', $request->from))
+            ->when($request->to,              fn ($q) => $q->whereDate('created_at', '<=', $request->to));
+
+        $paginated = $this->paginateWithCursor($query, $request, 50, 'created_at');
+
+        return response()->json([
+            'data'        => $paginated['data'],
+            'next_cursor' => $paginated['next_cursor'],
+            'has_more'    => $paginated['has_more'],
+        ]);
+    }
+
+    public function show(Request $request, int $id): JsonResponse
+    {
+        $log = AuditLog::with('user:id,name,email')
+            ->forTenant($request->user()->tenant_id)
+            ->findOrFail($id);
+
+        return response()->json(['data' => $log]);
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AuditLog extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'tenant_id', 'user_id', 'action', 'auditable_type', 'auditable_id',
+        'old_values', 'new_values', 'ip_address', 'user_agent', 'created_at',
+    ];
+
+    protected $casts = [
+        'old_values'  => 'array',
+        'new_values'  => 'array',
+        'created_at'  => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeForTenant($query, int $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+}

--- a/database/migrations/2024_01_15_000020_create_audit_logs_table.php
+++ b/database/migrations/2024_01_15_000020_create_audit_logs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('action', 100)->index();
+            $table->string('auditable_type', 100)->nullable()->index();
+            $table->unsignedBigInteger('auditable_id')->nullable();
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('created_at')->useCurrent()->index();
+
+            $table->index(['tenant_id', 'auditable_type', 'auditable_id']);
+            $table->index(['tenant_id', 'created_at']);
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};


### PR DESCRIPTION
## Summary

- `audit_logs` migration: tenant-scoped, composite indexes on `(tenant_id, auditable_type, auditable_id)` and `(tenant_id, created_at)`
- `AuditLog` model with `old_values`/`new_values` JSON casts and `user` relationship
- `AuditLogController::index` — filterable by action, auditable type/id, user, date range; cursor-paginated via `HasCursorPagination` trait
- `AuditLogController::show` — single log entry with user eager-load

## Test plan
- [ ] `GET /api/audit-logs?action=expense.submitted` — returns filtered results
- [ ] `GET /api/audit-logs?from=2024-01-01&to=2024-01-31` — date range filter
- [ ] Cross-tenant: cannot access another tenant's logs (404)
- [ ] Cursor pagination: next_cursor advances correctly through large log sets

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_