### PR TITLE
feat: dark/light/system theme toggle with localStorage persistence

### DIFF
--- a/resources/js/components/ThemeToggle.tsx
+++ b/resources/js/components/ThemeToggle.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Theme, useTheme } from '../hooks/useTheme';
+
+const SunIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 8a4 4 0 100 8 4 4 0 000-8z" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+  </svg>
+);
+
+const MonitorIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+  </svg>
+);
+
+const OPTIONS: { value: Theme; label: string; icon: React.ReactNode }[] = [
+  { value: 'light',  label: 'Light',  icon: <SunIcon /> },
+  { value: 'dark',   label: 'Dark',   icon: <MoonIcon /> },
+  { value: 'system', label: 'System', icon: <MonitorIcon /> },
+];
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+  const [open, setOpen]     = React.useState(false);
+  const ref                 = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const current = OPTIONS.find(o => o.value === theme)!;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        aria-label="Toggle theme"
+        aria-expanded={open}
+        onClick={() => setOpen(prev => !prev)}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        {current.icon}
+        <span className="hidden sm:inline">{current.label}</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 w-36 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+          {OPTIONS.map(opt => (
+            <button
+              key={opt.value}
+              onClick={() => { setTheme(opt.value); setOpen(false); }}
+              className={`w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                theme === opt.value
+                  ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              {opt.icon}
+              {opt.label}
+              {theme === opt.value && (
+                <svg className="w-3.5 h-3.5 ml-auto" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/resources/js/hooks/useTheme.ts
+++ b/resources/js/hooks/useTheme.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'expense-theme';
+
+const applyTheme = (theme: Theme) => {
+  const root = document.documentElement;
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+  root.classList.toggle('dark', isDark);
+  root.setAttribute('data-theme', isDark ? 'dark' : 'light');
+};
+
+export const useTheme = () => {
+  const [theme, setThemeState] = useState<Theme>(
+    () => (localStorage.getItem(STORAGE_KEY) as Theme) ?? 'system'
+  );
+
+  useEffect(() => {
+    applyTheme(theme);
+
+    if (theme !== 'system') return;
+
+    const mq      = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => applyTheme('system');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  };
+
+  return { theme, setTheme };
+};


### PR DESCRIPTION
## Summary

- `useTheme` hook: reads/writes `expense-theme` to localStorage; applies `.dark` class and `data-theme` attribute to `<html>`
- System mode subscribes to `prefers-color-scheme` media query and reacts to OS changes
- `ThemeToggle` component: dropdown with Light/Sun, Dark/Moon, System/Monitor options; checkmark on active choice
- Click-outside closes dropdown; `aria-expanded` for accessibility

## Test plan
- [ ] Select Dark → page switches to dark immediately, persists on reload
- [ ] Select System → follows OS theme; switch OS dark mode → page updates without reload
- [ ] ThemeToggle appears in header; correct icon shown for current mode
- [ ] Click outside dropdown → closes

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_