### PR TITLE
feat: expense attachments API with S3 upload, MIME validation, and presigned URLs

### DIFF
--- a/app/Http/Controllers/Api/ExpenseAttachmentController.php
+++ b/app/Http/Controllers/Api/ExpenseAttachmentController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Expense;
+use App\Models\ExpenseAttachment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ExpenseAttachmentController extends Controller
+{
+    private const ALLOWED_MIMES = [
+        'image/jpeg', 'image/png', 'image/webp',
+        'application/pdf',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.ms-excel',
+    ];
+
+    private const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+    public function index(Request $request, int $expenseId): JsonResponse
+    {
+        $expense     = Expense::where('tenant_id', $request->user()->tenant_id)->findOrFail($expenseId);
+        $attachments = ExpenseAttachment::where('expense_id', $expense->id)
+            ->with('uploader:id,name')
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn ($a) => array_merge($a->toArray(), [
+                'download_url' => Storage::disk('s3')->temporaryUrl($a->s3_key, now()->addMinutes(15)),
+            ]));
+
+        return response()->json(['data' => $attachments]);
+    }
+
+    public function store(Request $request, int $expenseId): JsonResponse
+    {
+        $expense = Expense::where('tenant_id', $request->user()->tenant_id)->findOrFail($expenseId);
+
+        $request->validate([
+            'file' => ['required', 'file', 'max:10240'],
+        ]);
+
+        $file = $request->file('file');
+
+        if (!in_array($file->getMimeType(), self::ALLOWED_MIMES, true)) {
+            return response()->json(['message' => 'File type not allowed'], 422);
+        }
+
+        if ($file->getSize() > self::MAX_SIZE_BYTES) {
+            return response()->json(['message' => 'File too large (max 10 MB)'], 422);
+        }
+
+        $s3Key = sprintf(
+            'tenants/%d/expenses/%d/attachments/%s.%s',
+            $request->user()->tenant_id,
+            $expense->id,
+            Str::uuid(),
+            $file->getClientOriginalExtension()
+        );
+
+        Storage::disk('s3')->put($s3Key, $file->getContent(), [
+            'ServerSideEncryption' => 'aws:kms',
+            'ContentType'          => $file->getMimeType(),
+        ]);
+
+        $attachment = ExpenseAttachment::create([
+            'tenant_id'         => $request->user()->tenant_id,
+            'expense_id'        => $expense->id,
+            'uploaded_by'       => $request->user()->id,
+            'original_filename' => $file->getClientOriginalName(),
+            's3_key'            => $s3Key,
+            'mime_type'         => $file->getMimeType(),
+            'size_bytes'        => $file->getSize(),
+        ]);
+
+        return response()->json(['data' => $attachment], 201);
+    }
+
+    public function destroy(Request $request, int $expenseId, int $attachmentId): JsonResponse
+    {
+        $attachment = ExpenseAttachment::where('expense_id', $expenseId)
+            ->where('tenant_id', $request->user()->tenant_id)
+            ->findOrFail($attachmentId);
+
+        Storage::disk('s3')->delete($attachment->s3_key);
+        $attachment->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/database/migrations/2024_01_15_000025_create_expense_attachments_table.php
+++ b/database/migrations/2024_01_15_000025_create_expense_attachments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expense_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('expense_id')->index();
+            $table->unsignedBigInteger('uploaded_by');
+            $table->string('original_filename', 255);
+            $table->string('s3_key', 500);
+            $table->string('mime_type', 100);
+            $table->unsignedBigInteger('size_bytes');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('expense_id')->references('id')->on('expenses')->cascadeOnDelete();
+            $table->foreign('uploaded_by')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_attachments');
+    }
+};


### PR DESCRIPTION
## Summary

- `expense_attachments` migration: tenant-scoped, soft-deletes, stores `s3_key`, `mime_type`, `size_bytes`, `original_filename`
- `ExpenseAttachmentController`: `index` returns list with 15-min presigned download URLs, `store` validates MIME + size server-side (not just client), uploads with KMS SSE to S3, `destroy` deletes from S3 then soft-deletes record
- Allowed types: JPEG, PNG, WebP, PDF, XLSX, XLS; max 10 MB
- S3 key format: `tenants/{id}/expenses/{id}/attachments/{uuid}.ext`

## Test plan
- [ ] Upload PDF → stored in S3 at correct key path, record created
- [ ] Upload disallowed MIME → 422
- [ ] File > 10MB → 422
- [ ] `GET` index → presigned URLs with 15-min expiry returned
- [ ] `DELETE` → S3 object removed, soft-delete sets `deleted_at`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_