### PR TITLE
feat: user profile API with avatar upload, timezone, locale, and password change

### DIFF
--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+
+class UserProfileController extends Controller
+{
+    private const ALLOWED_TIMEZONES = [
+        'Asia/Tokyo', 'Asia/Osaka', 'America/New_York', 'America/Los_Angeles',
+        'America/Chicago', 'Europe/London', 'Europe/Paris', 'Europe/Berlin',
+        'UTC',
+    ];
+
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user()->load('department:id,name');
+
+        return response()->json([
+            'data' => [
+                'id'            => $user->id,
+                'name'          => $user->name,
+                'email'         => $user->email,
+                'role'          => $user->role,
+                'timezone'      => $user->timezone ?? 'Asia/Tokyo',
+                'locale'        => $user->locale ?? 'ja',
+                'avatar_url'    => $user->avatar_url,
+                'department'    => $user->department,
+                'two_factor_enabled' => (bool) $user->two_factor_enabled,
+                'created_at'    => $user->created_at,
+            ],
+        ]);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $data = $request->validate([
+            'name'     => 'sometimes|string|max:100',
+            'timezone' => ['sometimes', Rule::in(self::ALLOWED_TIMEZONES)],
+            'locale'   => 'sometimes|in:ja,en',
+        ]);
+
+        $user->update($data);
+
+        return response()->json(['data' => $user->fresh()]);
+    }
+
+    public function updateAvatar(Request $request): JsonResponse
+    {
+        $request->validate([
+            'avatar' => 'required|image|mimes:jpeg,png,webp|max:2048',
+        ]);
+
+        $user = $request->user();
+        $file = $request->file('avatar');
+
+        // Delete old avatar
+        if ($user->avatar_url) {
+            $oldKey = parse_url($user->avatar_url, PHP_URL_PATH);
+            Storage::disk('s3')->delete(ltrim($oldKey, '/'));
+        }
+
+        $key = sprintf(
+            'avatars/%d/%s.%s',
+            $user->id,
+            Str::uuid(),
+            $file->getClientOriginalExtension()
+        );
+
+        Storage::disk('s3')->put($key, $file->getContent(), [
+            'ServerSideEncryption' => 'aws:kms',
+            'ContentType'          => $file->getMimeType(),
+            'CacheControl'         => 'public, max-age=31536000',
+        ]);
+
+        $avatarUrl = Storage::disk('s3')->url($key);
+        $user->update(['avatar_url' => $avatarUrl]);
+
+        return response()->json(['data' => ['avatar_url' => $avatarUrl]]);
+    }
+
+    public function changePassword(Request $request): JsonResponse
+    {
+        $request->validate([
+            'current_password' => 'required|string',
+            'password'         => 'required|string|min:12|confirmed|different:current_password',
+        ]);
+
+        $user = $request->user();
+
+        if (!Hash::check($request->current_password, $user->password)) {
+            return response()->json(['message' => 'Current password is incorrect'], 403);
+        }
+
+        $user->update(['password' => Hash::make($request->password)]);
+
+        // Revoke all other sessions
+        $user->tokens()->where('id', '!=', $request->user()->currentAccessToken()->id)->delete();
+
+        return response()->json(['message' => 'Password updated. Other sessions have been logged out.']);
+    }
+}

--- a/database/migrations/2024_01_15_000026_add_profile_columns_to_users_table.php
+++ b/database/migrations/2024_01_15_000026_add_profile_columns_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('timezone', 50)->default('Asia/Tokyo')->after('email');
+            $table->string('locale', 10)->default('ja')->after('timezone');
+            $table->string('avatar_url')->nullable()->after('locale');
+            $table->unsignedBigInteger('department_id')->nullable()->after('avatar_url');
+
+            $table->foreign('department_id')->references('id')->on('departments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['department_id']);
+            $table->dropColumn(['timezone', 'locale', 'avatar_url', 'department_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- `UserProfileController`: `show`, `update` (name/timezone/locale), `updateAvatar` (S3 KMS upload, old avatar deletion), `changePassword` (revokes other sessions on success)
- Migration adds `timezone`, `locale`, `avatar_url`, `department_id` columns to `users`
- Timezone validated against allowlist of 9 zones; locale restricted to `ja`/`en`
- Avatar S3 key: `avatars/{user_id}/{uuid}.ext`; public CDN URL stored in DB

## Test plan
- [ ] `GET /api/profile` returns all profile fields including department
- [ ] `PATCH /api/profile` with invalid timezone → 422
- [ ] `POST /api/profile/avatar` with valid JPEG → uploads to S3, URL returned
- [ ] `POST /api/profile/password` with wrong current → 403; correct → other tokens revoked

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_