### PR TITLE
feat: multi-currency conversion service with Redis cache and fallback rates

### DIFF
--- a/app/Http/Controllers/Api/CurrencyController.php
+++ b/app/Http/Controllers/Api/CurrencyController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\CurrencyConversionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CurrencyController extends Controller
+{
+    public function __construct(private readonly CurrencyConversionService $fx) {}
+
+    public function rates(Request $request): JsonResponse
+    {
+        $request->validate(['base' => 'nullable|string|size:3']);
+        $base = strtoupper($request->query('base', 'JPY'));
+
+        $currencies = $this->fx->getSupportedCurrencies();
+        $rates = [];
+        foreach (array_filter($currencies, fn ($c) => $c !== $base) as $to) {
+            $rates[$to] = $this->fx->getRate($base, $to);
+        }
+
+        return response()->json([
+            'base'  => $base,
+            'rates' => $rates,
+        ]);
+    }
+
+    public function convert(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'amount'   => 'required|integer|min:0',
+            'from'     => 'required|string|size:3',
+            'to'       => 'required|string|size:3',
+        ]);
+
+        $converted = $this->fx->convert((int) $data['amount'], strtoupper($data['from']), strtoupper($data['to']));
+
+        return response()->json([
+            'original'  => $data['amount'],
+            'converted' => $converted,
+            'from'      => strtoupper($data['from']),
+            'to'        => strtoupper($data['to']),
+            'rate'      => $this->fx->getRate(strtoupper($data['from']), strtoupper($data['to'])),
+        ]);
+    }
+}

--- a/app/Services/CurrencyConversionService.php
+++ b/app/Services/CurrencyConversionService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class CurrencyConversionService
+{
+    private const CACHE_TTL_SECONDS = 3600;
+    private const BASE_CURRENCY     = 'JPY';
+
+    public function convert(int $amountInLowest, string $fromCurrency, string $toCurrency = self::BASE_CURRENCY): int
+    {
+        if ($fromCurrency === $toCurrency) {
+            return $amountInLowest;
+        }
+
+        $rate = $this->getRate($fromCurrency, $toCurrency);
+
+        return (int) round($amountInLowest * $rate);
+    }
+
+    public function getRate(string $from, string $to): float
+    {
+        $cacheKey = "fx_rate:{$from}:{$to}";
+
+        return Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($from, $to) {
+            return $this->fetchRateFromProvider($from, $to);
+        });
+    }
+
+    public function getSupportedCurrencies(): array
+    {
+        return ['JPY', 'USD', 'EUR', 'GBP', 'CNY', 'KRW', 'SGD', 'HKD', 'AUD', 'CAD'];
+    }
+
+    private function fetchRateFromProvider(string $from, string $to): float
+    {
+        try {
+            $response = Http::timeout(5)->get(
+                "https://api.exchangerate-api.com/v4/latest/{$from}"
+            );
+
+            if ($response->successful()) {
+                return $response->json("rates.{$to}") ?? throw new \RuntimeException("Rate not found for {$to}");
+            }
+        } catch (\Throwable $e) {
+            Log::warning('Exchange rate fetch failed', ['from' => $from, 'to' => $to, 'error' => $e->getMessage()]);
+        }
+
+        // Fallback to hardcoded approximate rates
+        return $this->fallbackRate($from, $to);
+    }
+
+    private function fallbackRate(string $from, string $to): float
+    {
+        // Approximate rates relative to JPY (updated manually for fallback only)
+        $toJpy = [
+            'JPY' => 1.0, 'USD' => 150.0, 'EUR' => 163.0, 'GBP' => 190.0,
+            'CNY' => 21.0, 'KRW' => 0.11, 'SGD' => 111.0, 'HKD' => 19.2,
+            'AUD' => 99.0, 'CAD' => 110.0,
+        ];
+
+        $fromJpy = $toJpy[$from] ?? 1.0;
+        $toJpyV  = $toJpy[$to]   ?? 1.0;
+
+        return $fromJpy / $toJpyV;
+    }
+}


### PR DESCRIPTION
## Summary

- `CurrencyConversionService`: `convert(amount, from, to)`, `getRate(from, to)`, `getSupportedCurrencies()`
- Rates cached in Redis for 1 hour via `Cache::remember`; fetches from `exchangerate-api.com` with 5s timeout
- Fallback to hardcoded approximate rates on provider failure (logged as warning)
- `CurrencyController`: `GET /api/currencies/rates?base=USD` returns all supported rates, `POST /api/currencies/convert` converts a specific amount

## Test plan
- [ ] `GET /api/currencies/rates` → returns rates relative to JPY
- [ ] `POST /api/currencies/convert` with `{amount:100000, from:'USD', to:'JPY'}` → returns converted amount and rate
- [ ] Provider down → fallback rates used, warning logged
- [ ] Second call within 1 hour → served from cache (verify with Redis `TTL` command)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_