### PR TITLE
feat: tenant settings API for currency, fiscal year, and approval thresholds

### DIFF
--- a/app/Http/Controllers/Api/Admin/TenantSettingsController.php
+++ b/app/Http/Controllers/Api/Admin/TenantSettingsController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\TenantSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TenantSettingsController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $settings = TenantSettings::firstOrCreate(
+            ['tenant_id' => $request->user()->tenant_id],
+            [
+                'default_currency'       => 'JPY',
+                'fiscal_year_start_month'=> 1,
+                'notification_channels'  => ['email', 'in_app'],
+            ]
+        );
+
+        return response()->json(['data' => $settings]);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'default_currency'              => 'sometimes|string|size:3|in:JPY,USD,EUR,GBP,CNY,KRW,SGD,HKD,AUD,CAD',
+            'fiscal_year_start_month'       => 'sometimes|integer|min:1|max:12',
+            'auto_approve_below'            => 'nullable|integer|min:0',
+            'require_receipt_above'         => 'nullable|integer|min:0',
+            'allow_draft_edit_after_submit' => 'sometimes|boolean',
+            'require_department'            => 'sometimes|boolean',
+            'notification_channels'         => 'sometimes|array',
+            'notification_channels.*'       => 'in:email,slack,in_app',
+        ]);
+
+        $settings = TenantSettings::updateOrCreate(
+            ['tenant_id' => $request->user()->tenant_id],
+            $data
+        );
+
+        return response()->json(['data' => $settings->fresh()]);
+    }
+}

--- a/app/Models/TenantSettings.php
+++ b/app/Models/TenantSettings.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TenantSettings extends Model
+{
+    protected $fillable = [
+        'tenant_id', 'default_currency', 'fiscal_year_start_month',
+        'auto_approve_below', 'require_receipt_above',
+        'allow_draft_edit_after_submit', 'require_department',
+        'notification_channels',
+    ];
+
+    protected $casts = [
+        'fiscal_year_start_month'       => 'integer',
+        'auto_approve_below'            => 'integer',
+        'require_receipt_above'         => 'integer',
+        'allow_draft_edit_after_submit' => 'boolean',
+        'require_department'            => 'boolean',
+        'notification_channels'         => 'array',
+    ];
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/database/migrations/2024_01_15_000027_create_tenant_settings_table.php
+++ b/database/migrations/2024_01_15_000027_create_tenant_settings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tenant_settings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->unique();
+            $table->string('default_currency', 3)->default('JPY');
+            $table->unsignedTinyInteger('fiscal_year_start_month')->default(1);
+            $table->unsignedBigInteger('auto_approve_below')->nullable()->comment('Auto-approve expenses below this amount in lowest currency unit');
+            $table->unsignedBigInteger('require_receipt_above')->nullable();
+            $table->boolean('allow_draft_edit_after_submit')->default(false);
+            $table->boolean('require_department')->default(false);
+            $table->json('notification_channels')->nullable()->comment('Enabled channels: email, slack, in_app');
+            $table->timestamps();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_settings');
+    }
+};


### PR DESCRIPTION
## Summary

- `tenant_settings` migration: one-to-one with `tenants`, stores default currency, fiscal year start, auto-approve threshold, receipt requirement, notification channels
- `TenantSettings` model with JSON cast for `notification_channels` array
- `TenantSettingsController`: `show` uses `firstOrCreate` (idempotent, seeds defaults on first call), `update` validates against allowlists

## Test plan
- [ ] `GET /api/admin/settings` first call → creates default record, returns settings
- [ ] `PATCH /api/admin/settings` with `default_currency: 'USD'` → persisted
- [ ] `notification_channels: ['email', 'slack']` validated; `['sms']` → 422
- [ ] Cross-tenant: one tenant's settings cannot be read/updated by another

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_