### PR TITLE
feat: recurring expense schedules with Artisan processing command

### DIFF
--- a/app/Console/Commands/ProcessRecurringExpenses.php
+++ b/app/Console/Commands/ProcessRecurringExpenses.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Expense;
+use App\Models\RecurringExpense;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class ProcessRecurringExpenses extends Command
+{
+    protected $signature   = 'expenses:process-recurring {--dry-run : Preview without creating expenses}';
+    protected $description = 'Create expense entries from due recurring schedules';
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+        $due    = RecurringExpense::dueToday()->with('user')->get();
+
+        $this->info("Found {$due->count()} recurring expense(s) due today.");
+
+        $created = 0;
+        $failed  = 0;
+
+        foreach ($due as $recurring) {
+            try {
+                DB::transaction(function () use ($recurring, $dryRun, &$created) {
+                    if (!$dryRun) {
+                        Expense::create([
+                            'tenant_id'   => $recurring->tenant_id,
+                            'user_id'     => $recurring->user_id,
+                            'title'       => $recurring->title,
+                            'description' => $recurring->description,
+                            'amount'      => $recurring->amount,
+                            'currency'    => $recurring->currency,
+                            'category_id' => $recurring->category_id,
+                            'status'      => 'pending',
+                            'expense_date' => now()->toDateString(),
+                            'metadata'    => array_merge(
+                                $recurring->metadata ?? [],
+                                ['recurring_id' => $recurring->id]
+                            ),
+                        ]);
+
+                        $recurring->advanceNextRunDate();
+                        $recurring->save();
+                    }
+                    $created++;
+                });
+
+                $this->line(" ✓ [{$recurring->id}] {$recurring->title} ({$recurring->amount} {$recurring->currency})");
+            } catch (\Throwable $e) {
+                $failed++;
+                Log::error('ProcessRecurringExpenses failed', [
+                    'recurring_id' => $recurring->id,
+                    'error'        => $e->getMessage(),
+                ]);
+                $this->error(" ✗ [{$recurring->id}] {$recurring->title}: {$e->getMessage()}");
+            }
+        }
+
+        $this->info("{$created} expense(s) " . ($dryRun ? 'would be' : '') . " created. {$failed} failed.");
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/RecurringExpenseController.php
+++ b/app/Http/Controllers/Api/RecurringExpenseController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\RecurringExpense;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class RecurringExpenseController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $recurring = RecurringExpense::forTenant(Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->when($request->status, fn($q) => $q->where('status', $request->status))
+            ->with('category:id,name,color')
+            ->orderBy('next_run_date')
+            ->paginate(20);
+
+        return response()->json($recurring);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'title'            => 'required|string|max:200',
+            'description'      => 'nullable|string|max:1000',
+            'amount'           => 'required|numeric|min:0.01|max:9999999.99',
+            'currency'         => 'required|string|size:3',
+            'category_id'      => 'nullable|integer|exists:expense_categories,id',
+            'frequency'        => 'required|in:daily,weekly,monthly,quarterly,annual',
+            'interval'         => 'nullable|integer|min:1|max:12',
+            'next_run_date'    => 'required|date|after_or_equal:today',
+            'end_date'         => 'nullable|date|after:next_run_date',
+            'max_occurrences'  => 'nullable|integer|min:1|max:999',
+        ]);
+
+        $recurring = RecurringExpense::create(array_merge($validated, [
+            'tenant_id' => Auth::user()->tenant_id,
+            'user_id'   => Auth::id(),
+            'interval'  => $validated['interval'] ?? 1,
+        ]));
+
+        return response()->json($recurring, 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $recurring = RecurringExpense::forTenant(Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->with('category')
+            ->findOrFail($id);
+
+        return response()->json($recurring);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $recurring = RecurringExpense::forTenant(Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->findOrFail($id);
+
+        $validated = $request->validate([
+            'title'           => 'sometimes|string|max:200',
+            'description'     => 'sometimes|nullable|string|max:1000',
+            'amount'          => 'sometimes|numeric|min:0.01|max:9999999.99',
+            'end_date'        => 'sometimes|nullable|date',
+            'max_occurrences' => 'sometimes|nullable|integer|min:1',
+            'status'          => 'sometimes|in:active,paused,cancelled',
+        ]);
+
+        $recurring->update($validated);
+
+        return response()->json($recurring);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $recurring = RecurringExpense::forTenant(Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->findOrFail($id);
+
+        $recurring->update(['status' => 'cancelled']);
+        $recurring->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/RecurringExpense.php
+++ b/app/Models/RecurringExpense.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecurringExpense extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'user_id', 'title', 'description', 'amount', 'currency',
+        'category_id', 'frequency', 'interval', 'next_run_date', 'end_date',
+        'max_occurrences', 'occurrence_count', 'status', 'metadata',
+    ];
+
+    protected $casts = [
+        'amount'           => 'decimal:2',
+        'next_run_date'    => 'date',
+        'end_date'         => 'date',
+        'occurrence_count' => 'integer',
+        'max_occurrences'  => 'integer',
+        'interval'         => 'integer',
+        'metadata'         => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ExpenseCategory::class, 'category_id');
+    }
+
+    public function advanceNextRunDate(): void
+    {
+        $next = $this->next_run_date->copy();
+
+        $next = match ($this->frequency) {
+            'daily'     => $next->addDays($this->interval),
+            'weekly'    => $next->addWeeks($this->interval),
+            'monthly'   => $next->addMonthsNoOverflow($this->interval),
+            'quarterly' => $next->addMonthsNoOverflow($this->interval * 3),
+            'annual'    => $next->addYears($this->interval),
+            default     => $next->addMonthsNoOverflow($this->interval),
+        };
+
+        $this->occurrence_count++;
+
+        if (
+            ($this->end_date && $next->gt($this->end_date)) ||
+            ($this->max_occurrences && $this->occurrence_count >= $this->max_occurrences)
+        ) {
+            $this->status = 'completed';
+        } else {
+            $this->next_run_date = $next;
+        }
+    }
+
+    public function scopeForTenant($query, int $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopeDueToday($query)
+    {
+        return $query->where('status', 'active')
+                     ->where('next_run_date', '<=', now()->toDateString());
+    }
+}

--- a/database/migrations/2024_01_15_000029_create_recurring_expenses_table.php
+++ b/database/migrations/2024_01_15_000029_create_recurring_expenses_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('recurring_expenses', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('user_id');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->decimal('amount', 12, 2);
+            $table->string('currency', 3)->default('JPY');
+            $table->unsignedBigInteger('category_id')->nullable();
+            $table->string('frequency'); // daily, weekly, monthly, quarterly, annual
+            $table->unsignedSmallInteger('interval')->default(1);
+            $table->date('next_run_date');
+            $table->date('end_date')->nullable();
+            $table->unsignedInteger('max_occurrences')->nullable();
+            $table->unsignedInteger('occurrence_count')->default(0);
+            $table->enum('status', ['active', 'paused', 'completed', 'cancelled'])->default('active');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['tenant_id', 'status', 'next_run_date']);
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recurring_expenses');
+    }
+};


### PR DESCRIPTION
## Summary

- `recurring_expenses` table migration with frequency, interval, next_run_date, max_occurrences, and status
- `RecurringExpense` model with `advanceNextRunDate()` supporting daily/weekly/monthly/quarterly/annual frequencies using Carbon overflow-safe addition
- `ProcessRecurringExpenses` Artisan command with `--dry-run` flag; auto-completes schedule when end_date or max_occurrences reached
- `RecurringExpenseController` for full CRUD scoped to current user and tenant

## Test plan

- [ ] `php artisan expenses:process-recurring --dry-run` outputs due items without writing
- [ ] Monthly expense with interval=1 advances next_run_date by 1 month
- [ ] Schedule completes when max_occurrences reached
- [ ] Schedule completes when next date exceeds end_date
- [ ] Cross-tenant and cross-user access returns 404


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_