### PR TITLE
feat: vendor management with spend stats and duplicate code guard

### DIFF
--- a/app/Http/Controllers/Api/VendorController.php
+++ b/app/Http/Controllers/Api/VendorController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Vendor;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class VendorController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $vendors = Vendor::forTenant(Auth::user()->tenant_id)
+            ->when($request->status, fn($q) => $q->where('status', $request->status))
+            ->when($request->search, fn($q) => $q->where(function ($q) use ($request) {
+                $q->where('name', 'like', "%{$request->search}%")
+                  ->orWhere('code', 'like', "%{$request->search}%")
+                  ->orWhere('email', 'like', "%{$request->search}%");
+            }))
+            ->withCount('expenses')
+            ->orderBy('name')
+            ->paginate(20);
+
+        return response()->json($vendors);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'          => 'required|string|max:200',
+            'code'          => 'nullable|string|max:50',
+            'email'         => 'nullable|email|max:200',
+            'phone'         => 'nullable|string|max:30',
+            'website'       => 'nullable|url|max:300',
+            'address'       => 'nullable|string|max:500',
+            'tax_id'        => 'nullable|string|max:50',
+            'payment_terms' => 'nullable|string|max:100',
+            'currency'      => 'nullable|string|size:3',
+            'notes'         => 'nullable|string|max:1000',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        if (!empty($validated['code'])) {
+            $exists = Vendor::forTenant($tenantId)
+                ->where('code', $validated['code'])
+                ->exists();
+            if ($exists) {
+                return response()->json(['message' => 'Vendor code already in use.'], 422);
+            }
+        }
+
+        $vendor = Vendor::create(array_merge($validated, ['tenant_id' => $tenantId]));
+
+        return response()->json($vendor, 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $vendor = Vendor::forTenant(Auth::user()->tenant_id)
+            ->withCount('expenses')
+            ->findOrFail($id);
+
+        return response()->json($vendor);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $vendor = Vendor::forTenant(Auth::user()->tenant_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'          => 'sometimes|string|max:200',
+            'email'         => 'sometimes|nullable|email|max:200',
+            'phone'         => 'sometimes|nullable|string|max:30',
+            'website'       => 'sometimes|nullable|url|max:300',
+            'address'       => 'sometimes|nullable|string|max:500',
+            'payment_terms' => 'sometimes|nullable|string|max:100',
+            'status'        => 'sometimes|in:active,inactive,blocked',
+            'notes'         => 'sometimes|nullable|string|max:1000',
+        ]);
+
+        $vendor->update($validated);
+
+        return response()->json($vendor);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $vendor = Vendor::forTenant(Auth::user()->tenant_id)->findOrFail($id);
+
+        if ($vendor->expenses()->exists()) {
+            return response()->json(['message' => 'Cannot delete vendor with linked expenses.'], 409);
+        }
+
+        $vendor->delete();
+        return response()->json(null, 204);
+    }
+
+    public function stats(int $id): JsonResponse
+    {
+        $vendor = Vendor::forTenant(Auth::user()->tenant_id)->findOrFail($id);
+
+        $stats = DB::table('expenses')
+            ->where('vendor_id', $id)
+            ->where('tenant_id', Auth::user()->tenant_id)
+            ->selectRaw('
+                COUNT(*) as total_count,
+                SUM(amount) as total_amount,
+                AVG(amount) as avg_amount,
+                MIN(expense_date) as first_expense,
+                MAX(expense_date) as last_expense,
+                COUNT(CASE WHEN status = \'approved\' THEN 1 END) as approved_count
+            ')
+            ->first();
+
+        return response()->json([
+            'vendor'         => $vendor,
+            'total_count'    => (int) $stats->total_count,
+            'total_amount'   => (float) $stats->total_amount,
+            'avg_amount'     => round((float) $stats->avg_amount, 2),
+            'first_expense'  => $stats->first_expense,
+            'last_expense'   => $stats->last_expense,
+            'approved_count' => (int) $stats->approved_count,
+        ]);
+    }
+}

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Vendor extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'name', 'code', 'email', 'phone', 'website',
+        'address', 'tax_id', 'payment_terms', 'currency', 'status', 'notes', 'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function getTotalSpentAttribute(): string
+    {
+        return $this->expenses()->sum('amount');
+    }
+
+    public function scopeForTenant($query, int $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('status', 'active');
+    }
+}

--- a/database/migrations/2024_01_15_000030_create_vendors_table.php
+++ b/database/migrations/2024_01_15_000030_create_vendors_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vendors', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name');
+            $table->string('code')->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('website')->nullable();
+            $table->text('address')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->string('payment_terms')->nullable();
+            $table->string('currency', 3)->default('JPY');
+            $table->enum('status', ['active', 'inactive', 'blocked'])->default('active');
+            $table->text('notes')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->index(['tenant_id', 'status']);
+            $table->index(['tenant_id', 'name']);
+        });
+
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->unsignedBigInteger('vendor_id')->nullable()->after('category_id');
+            $table->index('vendor_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropColumn('vendor_id');
+        });
+        Schema::dropIfExists('vendors');
+    }
+};


### PR DESCRIPTION
## Summary

- `vendors` table migration with tenant-scoped unique code, status (active/inactive/blocked), tax_id, payment_terms
- Adds `vendor_id` foreign key column to `expenses` table
- `Vendor` model with `scopeActive`, `scopeForTenant`, soft-deletes, and `total_spent` accessor
- `VendorController` with index (search + status filter), store, show, update, destroy, and a `stats` endpoint returning total/avg spend and first/last expense dates
- Destroy returns 409 if vendor has linked expenses

## Test plan

- [ ] `GET /api/vendors?search=acme` filters by name, code, and email
- [ ] `POST /api/vendors` returns 422 if code already used in same tenant
- [ ] `DELETE /api/vendors/{id}` returns 409 when vendor has expenses
- [ ] `GET /api/vendors/{id}/stats` returns correct aggregates
- [ ] Cross-tenant access returns 404


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_