### PR TITLE
feat: expense policy enforcement service with auto-flag/reject and 7 unit tests

### DIFF
--- a/app/Services/ExpensePolicyEnforcementService.php
+++ b/app/Services/ExpensePolicyEnforcementService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Expense;
+use App\Models\ExpensePolicy;
+use Illuminate\Support\Collection;
+
+class ExpensePolicyEnforcementService
+{
+    /**
+     * Check an expense against all active policies and return violations.
+     *
+     * @return Collection<array{policy_id: int, rule: string, message: string, action: string}>
+     */
+    public function evaluate(Expense $expense): Collection
+    {
+        $policies = ExpensePolicy::where('tenant_id', $expense->tenant_id)
+            ->where('is_active', true)
+            ->get();
+
+        $violations = collect();
+
+        foreach ($policies as $policy) {
+            $rules = $policy->rules ?? [];
+
+            foreach ($rules as $rule) {
+                if ($this->ruleMatches($expense, $rule)) {
+                    $violations->push([
+                        'policy_id' => $policy->id,
+                        'rule'      => $rule['type'],
+                        'message'   => $this->buildMessage($rule, $expense),
+                        'action'    => $rule['action'] ?? 'flag',
+                    ]);
+                }
+            }
+        }
+
+        return $violations;
+    }
+
+    public function enforce(Expense $expense): void
+    {
+        $violations = $this->evaluate($expense);
+
+        if ($violations->isEmpty()) {
+            return;
+        }
+
+        $autoReject = $violations->contains('action', 'reject');
+
+        $expense->update([
+            'policy_violations' => $violations->toArray(),
+            'status'            => $autoReject ? 'rejected' : 'flagged',
+            'rejection_reason'  => $autoReject
+                ? 'Automatically rejected: ' . $violations->where('action', 'reject')->first()['message']
+                : null,
+        ]);
+    }
+
+    private function ruleMatches(Expense $expense, array $rule): bool
+    {
+        return match ($rule['type']) {
+            'max_amount'        => $expense->amount > ($rule['limit'] ?? PHP_INT_MAX),
+            'category_blocked'  => in_array($expense->category_id, $rule['category_ids'] ?? [], strict: true),
+            'requires_receipt'  => $expense->amount >= ($rule['min_amount'] ?? 0)
+                                    && !$expense->attachments()->exists(),
+            'weekend_purchase'  => in_array(
+                                    now()->parse($expense->expense_date)->dayOfWeek,
+                                    [0, 6]
+                                   ) && !($rule['allow_weekend'] ?? false),
+            'daily_limit'       => $this->dailyTotal($expense) > ($rule['limit'] ?? PHP_INT_MAX),
+            'monthly_limit'     => $this->monthlyTotal($expense) > ($rule['limit'] ?? PHP_INT_MAX),
+            default             => false,
+        };
+    }
+
+    private function buildMessage(array $rule, Expense $expense): string
+    {
+        return match ($rule['type']) {
+            'max_amount'       => "Amount {$expense->amount} exceeds policy limit of {$rule['limit']}",
+            'category_blocked' => 'Expense category is not permitted under current policy',
+            'requires_receipt' => 'Receipt attachment required for expenses above ' . ($rule['min_amount'] ?? 0),
+            'weekend_purchase' => 'Weekend purchases require prior approval',
+            'daily_limit'      => 'Daily spend limit of ' . $rule['limit'] . ' would be exceeded',
+            'monthly_limit'    => 'Monthly spend limit of ' . $rule['limit'] . ' would be exceeded',
+            default            => 'Policy violation: ' . $rule['type'],
+        };
+    }
+
+    private function dailyTotal(Expense $expense): float
+    {
+        return (float) Expense::where('tenant_id', $expense->tenant_id)
+            ->where('user_id', $expense->user_id)
+            ->where('expense_date', $expense->expense_date)
+            ->where('id', '!=', $expense->id)
+            ->whereIn('status', ['pending', 'approved'])
+            ->sum('amount');
+    }
+
+    private function monthlyTotal(Expense $expense): float
+    {
+        $date = now()->parse($expense->expense_date);
+        return (float) Expense::where('tenant_id', $expense->tenant_id)
+            ->where('user_id', $expense->user_id)
+            ->whereYear('expense_date', $date->year)
+            ->whereMonth('expense_date', $date->month)
+            ->where('id', '!=', $expense->id)
+            ->whereIn('status', ['pending', 'approved'])
+            ->sum('amount');
+    }
+}

--- a/tests/Unit/ExpensePolicyEnforcementServiceTest.php
+++ b/tests/Unit/ExpensePolicyEnforcementServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Expense;
+use App\Models\ExpensePolicy;
+use App\Services\ExpensePolicyEnforcementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExpensePolicyEnforcementServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ExpensePolicyEnforcementService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ExpensePolicyEnforcementService();
+    }
+
+    public function test_no_violations_when_no_policies_exist(): void
+    {
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'amount' => 5000]);
+
+        $violations = $this->service->evaluate($expense);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function test_max_amount_rule_triggers_violation(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => true,
+            'rules'     => [['type' => 'max_amount', 'limit' => 10000, 'action' => 'flag']],
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'amount' => 15000]);
+
+        $violations = $this->service->evaluate($expense);
+
+        $this->assertCount(1, $violations);
+        $this->assertEquals('max_amount', $violations->first()['rule']);
+    }
+
+    public function test_amount_below_limit_passes(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => true,
+            'rules'     => [['type' => 'max_amount', 'limit' => 50000, 'action' => 'flag']],
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'amount' => 3000]);
+
+        $this->assertCount(0, $this->service->evaluate($expense));
+    }
+
+    public function test_category_blocked_rule_triggers(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => true,
+            'rules'     => [['type' => 'category_blocked', 'category_ids' => [5, 10], 'action' => 'reject']],
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'category_id' => 5]);
+
+        $violations = $this->service->evaluate($expense);
+
+        $this->assertCount(1, $violations);
+        $this->assertEquals('reject', $violations->first()['action']);
+    }
+
+    public function test_inactive_policies_are_skipped(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => false,
+            'rules'     => [['type' => 'max_amount', 'limit' => 100, 'action' => 'reject']],
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'amount' => 99999]);
+
+        $this->assertCount(0, $this->service->evaluate($expense));
+    }
+
+    public function test_enforce_sets_flagged_status_on_flag_action(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => true,
+            'rules'     => [['type' => 'max_amount', 'limit' => 1000, 'action' => 'flag']],
+        ]);
+
+        $expense = Expense::factory()->create(['tenant_id' => 1, 'amount' => 5000, 'status' => 'pending']);
+
+        $this->service->enforce($expense);
+
+        $this->assertEquals('flagged', $expense->fresh()->status);
+    }
+
+    public function test_enforce_sets_rejected_status_on_reject_action(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 1,
+            'is_active' => true,
+            'rules'     => [['type' => 'max_amount', 'limit' => 1000, 'action' => 'reject']],
+        ]);
+
+        $expense = Expense::factory()->create(['tenant_id' => 1, 'amount' => 50000, 'status' => 'pending']);
+
+        $this->service->enforce($expense);
+
+        $this->assertEquals('rejected', $expense->fresh()->status);
+        $this->assertNotNull($expense->fresh()->rejection_reason);
+    }
+
+    public function test_cross_tenant_policies_do_not_apply(): void
+    {
+        ExpensePolicy::factory()->create([
+            'tenant_id' => 99,
+            'is_active' => true,
+            'rules'     => [['type' => 'max_amount', 'limit' => 0, 'action' => 'reject']],
+        ]);
+
+        $expense = Expense::factory()->make(['tenant_id' => 1, 'amount' => 99999]);
+
+        $this->assertCount(0, $this->service->evaluate($expense));
+    }
+}


### PR DESCRIPTION
## Summary

- `ExpensePolicyEnforcementService::evaluate()` checks all active tenant policies and returns a collection of violations
- `enforce()` sets expense status to `flagged` or `rejected` and stores `policy_violations` JSON + `rejection_reason`
- Supports 6 rule types: `max_amount`, `category_blocked`, `requires_receipt`, `weekend_purchase`, `daily_limit`, `monthly_limit`
- 7 PHPUnit unit tests covering: no policies, max_amount trigger, amount below limit pass, category blocked with reject, inactive policies skipped, enforce flags, enforce rejects, cross-tenant isolation

## Test plan

- [ ] All 7 unit tests pass
- [ ] Inactive policies are not evaluated
- [ ] `reject` action overrides `flag` when both are present
- [ ] Cross-tenant policies cannot affect other tenants' expenses
- [ ] `daily_limit` and `monthly_limit` correctly sum existing expenses


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_