### PR TITLE
feat: CSV expense import job with dedup, validation, and S3 staging

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Jobs\ImportExpensesCsv;
+use App\Models\ExpenseImport;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ImportController extends Controller
+{
+    private const MAX_FILE_SIZE  = 5 * 1024 * 1024; // 5 MB
+    private const ALLOWED_MIMES  = ['text/csv', 'text/plain', 'application/vnd.ms-excel'];
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'file' => 'required|file|max:5120|mimes:csv,txt',
+        ]);
+
+        $file = $request->file('file');
+
+        // Server-side MIME validation
+        $mime = $file->getMimeType();
+        if (!in_array($mime, self::ALLOWED_MIMES, strict: true)) {
+            return response()->json(['message' => 'Only CSV files are accepted.'], 422);
+        }
+
+        $user     = Auth::user();
+        $s3Key    = "imports/{$user->tenant_id}/" . Str::uuid() . '.csv';
+
+        Storage::disk('s3')->put($s3Key, file_get_contents($file->getRealPath()), [
+            'ServerSideEncryption' => 'aws:kms',
+        ]);
+
+        $import = ExpenseImport::create([
+            'tenant_id'  => $user->tenant_id,
+            'user_id'    => $user->id,
+            's3_key'     => $s3Key,
+            'filename'   => $file->getClientOriginalName(),
+            'status'     => 'queued',
+        ]);
+
+        ImportExpensesCsv::dispatch(
+            $import->id,
+            $user->tenant_id,
+            $user->id,
+            $s3Key
+        )->onQueue('imports');
+
+        return response()->json([
+            'import_id' => $import->id,
+            'message'   => 'Import queued. You will be notified when processing is complete.',
+        ], 202);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $import = ExpenseImport::where('tenant_id', Auth::user()->tenant_id)
+            ->findOrFail($id);
+
+        return response()->json($import);
+    }
+
+    public function index(): JsonResponse
+    {
+        $imports = ExpenseImport::where('tenant_id', Auth::user()->tenant_id)
+            ->where('user_id', Auth::id())
+            ->orderBy('created_at', 'desc')
+            ->limit(20)
+            ->get();
+
+        return response()->json($imports);
+    }
+}

--- a/app/Jobs/ImportExpensesCsv.php
+++ b/app/Jobs/ImportExpensesCsv.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Expense;
+use App\Models\ExpenseImport;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use League\Csv\Reader;
+use League\Csv\Statement;
+
+class ImportExpensesCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+    public int $tries   = 2;
+
+    private const REQUIRED_HEADERS = ['title', 'amount', 'expense_date', 'currency'];
+    private const MAX_ROWS = 5000;
+
+    public function __construct(
+        private readonly int    $importId,
+        private readonly int    $tenantId,
+        private readonly int    $userId,
+        private readonly string $s3Key,
+    ) {}
+
+    public function handle(): void
+    {
+        $import = ExpenseImport::findOrFail($this->importId);
+        $import->update(['status' => 'processing']);
+
+        try {
+            $csv     = $this->loadCsv();
+            $headers = $this->validateHeaders($csv);
+            $rows    = Statement::create()->process($csv);
+
+            $created = 0;
+            $skipped = 0;
+            $errors  = [];
+            $rowNum  = 1;
+
+            foreach ($rows as $row) {
+                if ($rowNum > self::MAX_ROWS) {
+                    $errors[] = "Import capped at " . self::MAX_ROWS . " rows.";
+                    break;
+                }
+
+                $result = $this->processRow($row, $rowNum);
+
+                if ($result === 'created') {
+                    $created++;
+                } elseif ($result === 'skipped') {
+                    $skipped++;
+                } else {
+                    $errors[] = $result;
+                }
+
+                $rowNum++;
+            }
+
+            $import->update([
+                'status'        => 'completed',
+                'rows_created'  => $created,
+                'rows_skipped'  => $skipped,
+                'error_details' => $errors ?: null,
+                'completed_at'  => now(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('ImportExpensesCsv failed', [
+                'import_id' => $this->importId,
+                'error'     => $e->getMessage(),
+            ]);
+            $import->update(['status' => 'failed', 'error_details' => [$e->getMessage()]]);
+            throw $e;
+        } finally {
+            Storage::disk('s3')->delete($this->s3Key);
+        }
+    }
+
+    private function loadCsv(): Reader
+    {
+        $content = Storage::disk('s3')->get($this->s3Key);
+        $csv     = Reader::createFromString($content);
+        $csv->setHeaderOffset(0);
+        return $csv;
+    }
+
+    private function validateHeaders(Reader $csv): array
+    {
+        $headers = $csv->getHeader();
+        $missing = array_diff(self::REQUIRED_HEADERS, $headers);
+        if ($missing) {
+            throw new \InvalidArgumentException(
+                'Missing required CSV columns: ' . implode(', ', $missing)
+            );
+        }
+        return $headers;
+    }
+
+    private function processRow(array $row, int $rowNum): string
+    {
+        $amount = filter_var($row['amount'] ?? '', FILTER_VALIDATE_FLOAT);
+        if ($amount === false || $amount <= 0) {
+            return "Row {$rowNum}: invalid amount '" . ($row['amount'] ?? '') . "'";
+        }
+
+        $date = $row['expense_date'] ?? '';
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return "Row {$rowNum}: invalid date '{$date}' (expected YYYY-MM-DD)";
+        }
+
+        $title = trim($row['title'] ?? '');
+        if ($title === '') {
+            return "Row {$rowNum}: title is required";
+        }
+
+        // Dedup by external_id if provided
+        $externalId = trim($row['external_id'] ?? '');
+        if ($externalId !== '') {
+            $exists = Expense::where('tenant_id', $this->tenantId)
+                ->where('external_id', $externalId)
+                ->exists();
+            if ($exists) {
+                return 'skipped';
+            }
+        }
+
+        Expense::create([
+            'tenant_id'    => $this->tenantId,
+            'user_id'      => $this->userId,
+            'title'        => $title,
+            'amount'       => $amount,
+            'currency'     => strtoupper(substr($row['currency'] ?? 'JPY', 0, 3)),
+            'expense_date' => $date,
+            'description'  => $row['description'] ?? null,
+            'status'       => 'pending',
+            'external_id'  => $externalId ?: null,
+        ]);
+
+        return 'created';
+    }
+}


### PR DESCRIPTION
## Summary

- `ImportExpensesCsv` queued job: loads CSV from S3, validates required headers (title, amount, expense_date, currency), processes up to 5,000 rows, and deduplicates via `external_id`
- `ImportController` with store (202 queued), show (status check), and index (last 20 imports) endpoints
- Server-side MIME validation (text/csv only), KMS-encrypted S3 upload on intake
- Job deletes staging S3 file on completion or failure; stores `rows_created`, `rows_skipped`, `error_details`

## Test plan

- [ ] `POST /api/imports` returns 202 with `import_id`
- [ ] Rows with duplicate `external_id` are skipped, not duplicated
- [ ] Row with invalid amount returns an error entry in `error_details`
- [ ] Missing required headers abort the job with status `failed`
- [ ] S3 staging file deleted after job completes
- [ ] Import capped at 5,000 rows with a notice in `error_details`


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_