### PR TITLE
feat: expense search API with multi-field filters, cursor pagination, and status aggregations

### DIFF
--- a/app/Http/Controllers/Api/ExpenseSearchController.php
+++ b/app/Http/Controllers/Api/ExpenseSearchController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ExpenseSearchController extends Controller
+{
+    private const PAGE_SIZE = 20;
+    private const MAX_PAGE_SIZE = 100;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate([
+            'q'            => 'nullable|string|max:200',
+            'status'       => 'nullable|array',
+            'status.*'     => 'in:pending,approved,rejected,flagged',
+            'category_ids' => 'nullable|array',
+            'category_ids.*' => 'integer',
+            'vendor_ids'   => 'nullable|array',
+            'vendor_ids.*' => 'integer',
+            'amount_min'   => 'nullable|numeric|min:0',
+            'amount_max'   => 'nullable|numeric|min:0',
+            'date_from'    => 'nullable|date',
+            'date_to'      => 'nullable|date|after_or_equal:date_from',
+            'user_ids'     => 'nullable|array',
+            'user_ids.*'   => 'integer',
+            'has_receipt'  => 'nullable|boolean',
+            'tags'         => 'nullable|array',
+            'sort_by'      => 'nullable|in:amount,expense_date,created_at,title',
+            'sort_dir'     => 'nullable|in:asc,desc',
+            'per_page'     => 'nullable|integer|min:1|max:100',
+            'cursor'       => 'nullable|string',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+        $perPage  = min($request->integer('per_page', self::PAGE_SIZE), self::MAX_PAGE_SIZE);
+        $sortBy   = $request->input('sort_by', 'expense_date');
+        $sortDir  = $request->input('sort_dir', 'desc');
+
+        $query = Expense::where('tenant_id', $tenantId)
+            ->with(['category:id,name,color', 'user:id,name', 'vendor:id,name'])
+            ->when($request->filled('q'), function ($q) use ($request) {
+                $term = '%' . addcslashes($request->q, '%_') . '%';
+                $q->where(function ($q) use ($term) {
+                    $q->where('title', 'like', $term)
+                      ->orWhere('description', 'like', $term);
+                });
+            })
+            ->when($request->filled('status'), fn($q) => $q->whereIn('status', $request->status))
+            ->when($request->filled('category_ids'), fn($q) => $q->whereIn('category_id', $request->category_ids))
+            ->when($request->filled('vendor_ids'), fn($q) => $q->whereIn('vendor_id', $request->vendor_ids))
+            ->when($request->filled('amount_min'), fn($q) => $q->where('amount', '>=', $request->amount_min))
+            ->when($request->filled('amount_max'), fn($q) => $q->where('amount', '<=', $request->amount_max))
+            ->when($request->filled('date_from'), fn($q) => $q->where('expense_date', '>=', $request->date_from))
+            ->when($request->filled('date_to'), fn($q) => $q->where('expense_date', '<=', $request->date_to))
+            ->when($request->filled('user_ids'), fn($q) => $q->whereIn('user_id', $request->user_ids))
+            ->when($request->boolean('has_receipt'), function ($q) {
+                $q->whereHas('attachments');
+            })
+            ->when($request->filled('tags'), function ($q) use ($request) {
+                foreach ($request->tags as $tag) {
+                    $q->whereJsonContains('tags', $tag);
+                }
+            });
+
+        // Cursor pagination
+        if ($request->filled('cursor')) {
+            $cursor = json_decode(base64_decode($request->cursor), true);
+            if ($cursor) {
+                $dir = $sortDir === 'asc' ? '>' : '<';
+                $query->where(function ($q) use ($sortBy, $dir, $cursor) {
+                    $q->where($sortBy, $dir, $cursor['val'])
+                      ->orWhere(function ($q) use ($sortBy, $dir, $cursor) {
+                          $q->where($sortBy, $cursor['val'])
+                            ->where('id', $dir, $cursor['id']);
+                      });
+                });
+            }
+        }
+
+        $items = $query
+            ->orderBy($sortBy, $sortDir)
+            ->orderBy('id', $sortDir)
+            ->limit($perPage + 1)
+            ->get();
+
+        $hasMore    = $items->count() > $perPage;
+        $results    = $hasMore ? $items->take($perPage) : $items;
+        $nextCursor = null;
+
+        if ($hasMore) {
+            $last       = $results->last();
+            $nextCursor = base64_encode(json_encode(['id' => $last->id, 'val' => $last->$sortBy]));
+        }
+
+        // Aggregations
+        $aggs = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->selectRaw('status, COUNT(*) as count, SUM(amount) as total')
+            ->when($request->filled('q'), function ($q) use ($request) {
+                $term = '%' . addcslashes($request->q, '%_') . '%';
+                $q->where(function ($q) use ($term) {
+                    $q->where('title', 'like', $term)->orWhere('description', 'like', $term);
+                });
+            })
+            ->groupBy('status')
+            ->get()
+            ->keyBy('status');
+
+        return response()->json([
+            'data'        => $results->values(),
+            'next_cursor' => $nextCursor,
+            'has_more'    => $hasMore,
+            'aggs'        => [
+                'by_status' => $aggs->map(fn($r) => [
+                    'count' => (int) $r->count,
+                    'total' => (float) $r->total,
+                ]),
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/ExpenseSearchTest.php
+++ b/tests/Feature/ExpenseSearchTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ExpenseSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+        Sanctum::actingAs($this->user);
+    }
+
+    public function test_returns_all_expenses_without_filters(): void
+    {
+        Expense::factory()->count(3)->create(['tenant_id' => 1, 'user_id' => $this->user->id]);
+
+        $response = $this->getJson('/api/expenses/search');
+
+        $response->assertOk();
+        $this->assertCount(3, $response->json('data'));
+    }
+
+    public function test_filters_by_keyword_in_title(): void
+    {
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'title' => 'Taxi to airport']);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'title' => 'Hotel stay']);
+
+        $response = $this->getJson('/api/expenses/search?q=taxi');
+
+        $response->assertOk();
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('Taxi to airport', $response->json('data.0.title'));
+    }
+
+    public function test_filters_by_status_array(): void
+    {
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'status' => 'approved']);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'status' => 'pending']);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'status' => 'rejected']);
+
+        $response = $this->getJson('/api/expenses/search?status[]=approved&status[]=pending');
+
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data'));
+    }
+
+    public function test_filters_by_amount_range(): void
+    {
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'amount' => 500]);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'amount' => 5000]);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'amount' => 50000]);
+
+        $response = $this->getJson('/api/expenses/search?amount_min=1000&amount_max=10000');
+
+        $response->assertOk();
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('5000.00', $response->json('data.0.amount'));
+    }
+
+    public function test_cross_tenant_expenses_not_returned(): void
+    {
+        Expense::factory()->create(['tenant_id' => 99, 'user_id' => $this->user->id, 'title' => 'Other tenant']);
+
+        $response = $this->getJson('/api/expenses/search?q=other+tenant');
+
+        $response->assertOk();
+        $this->assertCount(0, $response->json('data'));
+    }
+
+    public function test_cursor_pagination_returns_next_cursor(): void
+    {
+        Expense::factory()->count(5)->create(['tenant_id' => 1, 'user_id' => $this->user->id]);
+
+        $response = $this->getJson('/api/expenses/search?per_page=2');
+
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data'));
+        $this->assertTrue($response->json('has_more'));
+        $this->assertNotNull($response->json('next_cursor'));
+    }
+
+    public function test_aggregations_by_status_returned(): void
+    {
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'status' => 'approved', 'amount' => 1000]);
+        Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->user->id, 'status' => 'pending', 'amount' => 2000]);
+
+        $response = $this->getJson('/api/expenses/search');
+
+        $response->assertOk();
+        $aggs = $response->json('aggs.by_status');
+        $this->assertArrayHasKey('approved', $aggs);
+        $this->assertEquals(1, $aggs['approved']['count']);
+    }
+}


### PR DESCRIPTION
## Summary

- `ExpenseSearchController` (single-action invokable) with 14 filter parameters: keyword (title/description), status array, category_ids, vendor_ids, amount range, date range, user_ids, has_receipt, tags (JSON contains)
- Cursor pagination using base64-encoded `{id, val}` composite cursor and LIMIT+1 pattern
- Status aggregations (`aggs.by_status`) with count and total for each status value
- 6 PHPUnit feature tests: no filters, keyword filter, status array filter, amount range, cross-tenant isolation, cursor pagination, aggregations

## Test plan

- [ ] All 6 feature tests pass
- [ ] `q=taxi` matches title containing "Taxi" case-insensitively
- [ ] `status[]=approved&status[]=pending` returns only those statuses
- [ ] `amount_min=1000&amount_max=10000` filters correctly
- [ ] Cross-tenant expenses never appear in results
- [ ] `per_page=2` on 5 expenses returns `has_more: true` and `next_cursor`


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_