### PR TITLE
feat: CloudFront CDN distribution for SPA with S3 origin, OAC, and ALB API forwarding

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,174 @@
+# ── S3 bucket for frontend assets ───────────────────────────────────────────────────
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.project}-${var.environment}-frontend-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-frontend" })
+}
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket                  = aws_s3_bucket.frontend.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ── Origin Access Control ──────────────────────────────────────────────────────────
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project}-${var.environment}-frontend-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ── CloudFront distribution ───────────────────────────────────────────────────────
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = var.cloudfront_aliases
+  price_class         = "PriceClass_200" # US, Europe, Asia
+  web_acl_id          = var.waf_web_acl_arn
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "S3-${aws_s3_bucket.frontend.id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # API requests forwarded to ALB
+  origin {
+    domain_name = var.alb_dns_name
+    origin_id   = "ALB-api"
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.frontend.id}"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 86400   # 1 day
+    max_ttl     = 2592000 # 30 days
+  }
+
+  # API path forwarded to ALB
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "ALB-api"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = false
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Authorization", "Origin", "Accept", "Content-Type", "X-Requested-With"]
+      cookies { forward = "all" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # SPA fallback: 403/404 from S3 → serve index.html
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  logging_config {
+    bucket          = var.log_bucket_domain_name
+    prefix          = "cloudfront/${var.project}-${var.environment}/"
+    include_cookies = false
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-cdn" })
+}
+
+# ── S3 bucket policy: allow CloudFront OAC ──────────────────────────────────────
+data "aws_iam_policy_document" "frontend_bucket" {
+  statement {
+    sid     = "AllowCloudFrontOAC"
+    actions = ["s3:GetObject"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.frontend.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.frontend_bucket.json
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────────
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID (use for cache invalidation)"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "frontend_s3_bucket" {
+  description = "S3 bucket name for frontend asset deployment"
+  value       = aws_s3_bucket.frontend.id
+}

--- a/terraform/variables_cloudfront.tf
+++ b/terraform/variables_cloudfront.tf
@@ -1,0 +1,25 @@
+variable "cloudfront_aliases" {
+  description = "Custom domain aliases for CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of ACM certificate in us-east-1 for CloudFront HTTPS (must be in us-east-1)"
+  type        = string
+}
+
+variable "alb_dns_name" {
+  description = "ALB DNS name for CloudFront API origin"
+  type        = string
+}
+
+variable "log_bucket_domain_name" {
+  description = "S3 bucket domain name for CloudFront access logs"
+  type        = string
+}
+
+variable "waf_web_acl_arn" {
+  description = "WAFv2 Web ACL ARN (must be CLOUDFRONT scope, created in us-east-1)"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- KMS-encrypted S3 bucket for frontend assets with public access block and versioning
- `aws_cloudfront_origin_access_control` (OAC) using sigv4 — replaces legacy OAI
- CloudFront distribution with two origins: S3 (static assets) and ALB (API `/api/*`)
- `ordered_cache_behavior` for `/api/*` forwards Authorization header + all cookies, TTL=0
- Default behavior caches static assets (1-day default, 30-day max), `compress = true`
- Custom error responses: 403/404 from S3 → serve `index.html` (SPA client-side routing)
- WAFv2 Web ACL attached; TLSv1.2_2021 minimum; access logs to configurable S3 bucket
- S3 bucket policy scoped to CloudFront distribution ARN via OAC condition

## Test plan

- [ ] `terraform plan` completes without errors
- [ ] S3 bucket policy allows only the specific CloudFront distribution (not all CF)
- [ ] `/api/*` cache behavior has TTL=0 and forwards Authorization header
- [ ] 404 from S3 returns `index.html` with HTTP 200 (SPA fallback)
- [ ] OAC signing behavior is `always` with `sigv4` protocol


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_