### PR TITLE
feat: notification controller with mark-read, mark-all-read, and 5 feature tests

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'unread_only' => 'nullable|boolean',
+            'type'        => 'nullable|string|max:100',
+            'per_page'    => 'nullable|integer|min:1|max:50',
+        ]);
+
+        $user        = Auth::user();
+        $perPage     = $request->integer('per_page', 20);
+        $unreadOnly  = $request->boolean('unread_only', false);
+
+        $query = $user->notifications()
+            ->when($unreadOnly, fn($q) => $q->whereNull('read_at'))
+            ->when($request->filled('type'), fn($q) => $q->where('type', $request->type));
+
+        $notifications = $query->paginate($perPage);
+
+        return response()->json([
+            'data'         => $notifications->items(),
+            'unread_count' => $user->unreadNotifications()->count(),
+            'meta'         => [
+                'current_page' => $notifications->currentPage(),
+                'last_page'    => $notifications->lastPage(),
+                'total'        => $notifications->total(),
+            ],
+        ]);
+    }
+
+    public function markRead(string $id): JsonResponse
+    {
+        $notification = Auth::user()
+            ->notifications()
+            ->findOrFail($id);
+
+        $notification->markAsRead();
+
+        return response()->json([
+            'id'      => $notification->id,
+            'read_at' => $notification->read_at,
+        ]);
+    }
+
+    public function markAllRead(): JsonResponse
+    {
+        $count = Auth::user()->unreadNotifications()->count();
+        Auth::user()->unreadNotifications()->update(['read_at' => now()]);
+
+        return response()->json(['marked_read' => $count]);
+    }
+
+    public function destroy(string $id): JsonResponse
+    {
+        Auth::user()->notifications()->findOrFail($id)->delete();
+        return response()->json(null, 204);
+    }
+
+    public function destroyAll(): JsonResponse
+    {
+        $count = Auth::user()->notifications()->count();
+        Auth::user()->notifications()->delete();
+        return response()->json(['deleted' => $count]);
+    }
+}

--- a/tests/Feature/NotificationControllerTest.php
+++ b/tests/Feature/NotificationControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class NotificationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+        Sanctum::actingAs($this->user);
+    }
+
+    private function createNotification(bool $read = false): DatabaseNotification
+    {
+        $n = DatabaseNotification::create([
+            'id'              => \Str::uuid(),
+            'type'            => 'App\\Notifications\\TestNotification',
+            'notifiable_type' => User::class,
+            'notifiable_id'   => $this->user->id,
+            'data'            => ['title' => 'Test', 'body' => 'Hello'],
+            'read_at'         => $read ? now() : null,
+        ]);
+        return $n;
+    }
+
+    public function test_index_returns_all_notifications(): void
+    {
+        $this->createNotification();
+        $this->createNotification(read: true);
+
+        $response = $this->getJson('/api/notifications');
+
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data'));
+        $this->assertEquals(1, $response->json('unread_count'));
+    }
+
+    public function test_unread_only_filter(): void
+    {
+        $this->createNotification();
+        $this->createNotification(read: true);
+
+        $response = $this->getJson('/api/notifications?unread_only=1');
+
+        $response->assertOk();
+        $this->assertCount(1, $response->json('data'));
+    }
+
+    public function test_mark_read_sets_read_at(): void
+    {
+        $n = $this->createNotification();
+
+        $response = $this->patchJson("/api/notifications/{$n->id}/read");
+
+        $response->assertOk();
+        $this->assertNotNull($response->json('read_at'));
+        $this->assertNotNull($n->fresh()->read_at);
+    }
+
+    public function test_mark_all_read(): void
+    {
+        $this->createNotification();
+        $this->createNotification();
+
+        $response = $this->postJson('/api/notifications/read-all');
+
+        $response->assertOk();
+        $this->assertEquals(2, $response->json('marked_read'));
+        $this->assertEquals(0, $this->user->unreadNotifications()->count());
+    }
+
+    public function test_destroy_deletes_notification(): void
+    {
+        $n = $this->createNotification();
+
+        $this->deleteJson("/api/notifications/{$n->id}")->assertNoContent();
+
+        $this->assertDatabaseMissing('notifications', ['id' => $n->id]);
+    }
+}


### PR DESCRIPTION
## Summary

- `NotificationController` wrapping Laravel's `DatabaseNotification` model
- `GET /api/notifications` with `unread_only` and `type` filters; returns `unread_count` alongside paginated data
- `PATCH /api/notifications/{id}/read` marks a single notification read
- `POST /api/notifications/read-all` bulk-marks all unread; returns count
- `DELETE /api/notifications/{id}` and `DELETE /api/notifications` (all) endpoints
- 5 PHPUnit feature tests: index, unread filter, mark read, mark all read, delete

## Test plan

- [ ] All 5 tests pass
- [ ] `unread_only=1` excludes already-read notifications
- [ ] `unread_count` reflects current count of unread notifications
- [ ] Mark-read sets `read_at` timestamp and returns it
- [ ] Delete removes record from `notifications` table


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_