### PR TITLE
feat: TenantMiddleware for multi-tenant request scoping with suspended tenant guard

### DIFF
--- a/app/Http/Middleware/RequireVerifiedEmail.php
+++ b/app/Http/Middleware/RequireVerifiedEmail.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireVerifiedEmail
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if ($user && !$user->hasVerifiedEmail()) {
+            return response()->json([
+                'message'    => 'Email address not verified.',
+                'verify_url' => route('verification.notice'),
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/TenantMiddleware.php
+++ b/app/Http/Middleware/TenantMiddleware.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class TenantMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if (!$user || !$user->tenant_id) {
+            return response()->json(['message' => 'Tenant context not established.'], 403);
+        }
+
+        if (!$user->tenant?->is_active) {
+            return response()->json(['message' => 'Tenant account is suspended.'], 403);
+        }
+
+        // Bind the current tenant_id to the request so controllers can read it
+        app()->instance('current.tenant_id', $user->tenant_id);
+
+        return $next($request);
+    }
+}

--- a/tests/Unit/TenantMiddlewareTest.php
+++ b/tests/Unit/TenantMiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\TenantMiddleware;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class TenantMiddlewareTest extends TestCase
+{
+    private TenantMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->middleware = new TenantMiddleware();
+    }
+
+    public function test_unauthenticated_request_returns_403(): void
+    {
+        Auth::shouldReceive('user')->andReturn(null);
+
+        $request  = Request::create('/api/test');
+        $response = $this->middleware->handle($request, fn() => new Response());
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_user_without_tenant_id_returns_403(): void
+    {
+        $user = new User(['tenant_id' => null]);
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $request  = Request::create('/api/test');
+        $response = $this->middleware->handle($request, fn() => new Response());
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_user_with_inactive_tenant_returns_403(): void
+    {
+        $tenant = new Tenant(['is_active' => false]);
+        $user   = \Mockery::mock(User::class)->makePartial();
+        $user->tenant_id = 1;
+        $user->shouldReceive('getAttribute')->with('tenant')->andReturn($tenant);
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $request  = Request::create('/api/test');
+        $response = $this->middleware->handle($request, fn() => new Response());
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_valid_tenant_passes_through(): void
+    {
+        $tenant = new Tenant(['is_active' => true]);
+        $user   = \Mockery::mock(User::class)->makePartial();
+        $user->tenant_id = 5;
+        $user->shouldReceive('getAttribute')->with('tenant')->andReturn($tenant);
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $passed   = false;
+        $request  = Request::create('/api/test');
+        $response = $this->middleware->handle($request, function () use (&$passed) {
+            $passed = true;
+            return new Response('ok', 200);
+        });
+
+        $this->assertTrue($passed);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(5, app('current.tenant_id'));
+    }
+}


### PR DESCRIPTION
## Summary

- `TenantMiddleware` resolves `tenant_id` from authenticated user, returns 403 if absent or tenant inactive
- Binds `current.tenant_id` to the service container so controllers can read it via `app('current.tenant_id')`
- `RequireVerifiedEmail` middleware returns 403 with `verify_url` if email not yet verified
- 4 PHPUnit unit tests: unauthenticated → 403, no tenant_id → 403, inactive tenant → 403, valid tenant → passes through and binds tenant_id

## Test plan

- [ ] All 4 unit tests pass
- [ ] Unauthenticated request returns 403 with message
- [ ] User with suspended tenant (`is_active = false`) returns 403
- [ ] Valid tenant request passes through and `app('current.tenant_id')` equals `user->tenant_id`
- [ ] `RequireVerifiedEmail` blocks unverified users with verify URL in response


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_