### PR TITLE
feat: analytics controller with category breakdown, monthly trends, and top vendors

### DIFF
--- a/app/Http/Controllers/Api/AnalyticsController.php
+++ b/app/Http/Controllers/Api/AnalyticsController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class AnalyticsController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'period' => 'nullable|in:3m,6m,12m',
+        ]);
+
+        $tenantId  = Auth::user()->tenant_id;
+        $period    = $request->input('period', '12m');
+        $months    = (int) rtrim($period, 'm');
+        $startDate = now()->subMonths($months)->startOfMonth()->toDateString();
+
+        // Totals
+        $totals = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->where('expense_date', '>=', $startDate)
+            ->whereIn('status', ['approved', 'pending'])
+            ->selectRaw('COUNT(*) as total_count, COALESCE(SUM(amount), 0) as total_amount, COALESCE(AVG(amount), 0) as avg_amount')
+            ->first();
+
+        // Category breakdown
+        $categories = DB::table('expenses')
+            ->join('expense_categories', 'expenses.category_id', '=', 'expense_categories.id')
+            ->where('expenses.tenant_id', $tenantId)
+            ->where('expenses.expense_date', '>=', $startDate)
+            ->whereIn('expenses.status', ['approved', 'pending'])
+            ->selectRaw('
+                expense_categories.name as category,
+                expense_categories.color,
+                COUNT(*) as count,
+                COALESCE(SUM(expenses.amount), 0) as amount
+            ')
+            ->groupBy('expense_categories.id', 'expense_categories.name', 'expense_categories.color')
+            ->orderByDesc('amount')
+            ->get();
+
+        $totalCatAmount = $categories->sum('amount');
+        $categoriesWithPct = $categories->map(fn($c) => [
+            'category' => $c->category,
+            'color'    => $c->color ?? '#6b7280',
+            'count'    => (int) $c->count,
+            'amount'   => (float) $c->amount,
+            'pct'      => $totalCatAmount > 0
+                ? round($c->amount / $totalCatAmount * 100, 2)
+                : 0,
+        ]);
+
+        // Monthly trends
+        $monthlyTrends = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->where('expense_date', '>=', $startDate)
+            ->selectRaw("
+                DATE_FORMAT(expense_date, '%Y-%m') as month,
+                COALESCE(SUM(CASE WHEN status = 'approved' THEN amount ELSE 0 END), 0) as approved,
+                COALESCE(SUM(CASE WHEN status = 'rejected' THEN amount ELSE 0 END), 0) as rejected,
+                COALESCE(SUM(CASE WHEN status = 'pending'  THEN amount ELSE 0 END), 0) as pending
+            ")
+            ->groupByRaw("DATE_FORMAT(expense_date, '%Y-%m')")
+            ->orderBy('month')
+            ->get()
+            ->map(fn($r) => [
+                'month'    => $r->month,
+                'approved' => (float) $r->approved,
+                'rejected' => (float) $r->rejected,
+                'pending'  => (float) $r->pending,
+            ]);
+
+        // Top vendors
+        $topVendors = DB::table('expenses')
+            ->join('vendors', 'expenses.vendor_id', '=', 'vendors.id')
+            ->where('expenses.tenant_id', $tenantId)
+            ->where('expenses.expense_date', '>=', $startDate)
+            ->whereIn('expenses.status', ['approved', 'pending'])
+            ->selectRaw('vendors.name, COALESCE(SUM(expenses.amount), 0) as amount')
+            ->groupBy('vendors.id', 'vendors.name')
+            ->orderByDesc('amount')
+            ->limit(10)
+            ->get()
+            ->map(fn($r) => ['name' => $r->name, 'amount' => (float) $r->amount]);
+
+        return response()->json([
+            'total_amount'    => (float) $totals->total_amount,
+            'total_count'     => (int)   $totals->total_count,
+            'avg_amount'      => round((float) $totals->avg_amount, 2),
+            'categories'      => $categoriesWithPct,
+            'monthly_trends'  => $monthlyTrends,
+            'top_vendors'     => $topVendors,
+            'period'          => $period,
+            'start_date'      => $startDate,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- `AnalyticsController` returning tenant-scoped data for 3m/6m/12m periods
- Totals: `total_amount`, `total_count`, `avg_amount` across approved + pending expenses
- Category breakdown with `pct` percentage of total spend per category (colour from `expense_categories.color`)
- Monthly trends: per-month approved/rejected/pending amounts grouped by `DATE_FORMAT(expense_date, '%Y-%m')`
- Top 10 vendors by total spend; excludes expenses without a vendor
- All queries use a single `start_date` derived from the period parameter

## Test plan

- [ ] `GET /api/analytics?period=3m` returns data for last 3 months only
- [ ] `pct` values across all categories sum to 100
- [ ] Monthly trends array ordered by month ascending
- [ ] Cross-tenant data excluded from all aggregations
- [ ] `avg_amount` is 0 when no expenses in period (no division-by-zero)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_