### PR TITLE
feat: bulk actions controller for approve/reject/export/delete with tenant guard

### DIFF
--- a/app/Http/Controllers/Api/ExpenseBulkController.php
+++ b/app/Http/Controllers/Api/ExpenseBulkController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Jobs\ExportExpensesCsv;
+use App\Models\Expense;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ExpenseBulkController extends Controller
+{
+    private const ALLOWED_ACTIONS = ['approve', 'reject', 'export', 'delete'];
+    private const MAX_IDS = 500;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'action'          => 'required|in:approve,reject,export,delete',
+            'ids'             => 'required|array|min:1|max:' . self::MAX_IDS,
+            'ids.*'           => 'integer|min:1',
+            'rejection_reason'=> 'nullable|string|max:500',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+        $action   = $validated['action'];
+        $ids      = array_unique($validated['ids']);
+
+        // Verify all IDs belong to the current tenant
+        $count = Expense::where('tenant_id', $tenantId)
+            ->whereIn('id', $ids)
+            ->count();
+
+        if ($count !== count($ids)) {
+            return response()->json(['message' => 'One or more expense IDs are invalid.'], 422);
+        }
+
+        return match ($action) {
+            'approve' => $this->bulkApprove($ids, $tenantId),
+            'reject'  => $this->bulkReject($ids, $tenantId, $validated['rejection_reason'] ?? null),
+            'export'  => $this->bulkExport($ids, $tenantId),
+            'delete'  => $this->bulkDelete($ids, $tenantId),
+        };
+    }
+
+    private function bulkApprove(array $ids, int $tenantId): JsonResponse
+    {
+        $updated = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->whereIn('id', $ids)
+            ->where('status', 'pending')
+            ->update([
+                'status'      => 'approved',
+                'approved_by' => Auth::id(),
+                'approved_at' => now(),
+                'updated_at'  => now(),
+            ]);
+
+        return response()->json([
+            'action'  => 'approve',
+            'updated' => $updated,
+            'skipped' => count($ids) - $updated,
+        ]);
+    }
+
+    private function bulkReject(array $ids, int $tenantId, ?string $reason): JsonResponse
+    {
+        $updated = DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->whereIn('id', $ids)
+            ->where('status', 'pending')
+            ->update([
+                'status'           => 'rejected',
+                'rejection_reason' => $reason,
+                'updated_at'       => now(),
+            ]);
+
+        return response()->json([
+            'action'  => 'reject',
+            'updated' => $updated,
+            'skipped' => count($ids) - $updated,
+        ]);
+    }
+
+    private function bulkExport(array $ids, int $tenantId): JsonResponse
+    {
+        ExportExpensesCsv::dispatch(
+            Auth::user(),
+            ['ids' => $ids, 'tenant_id' => $tenantId]
+        )->onQueue('reports');
+
+        return response()->json([
+            'action'  => 'export',
+            'queued'  => count($ids),
+            'message' => 'Export queued. You will receive a download link by email.',
+        ], 202);
+    }
+
+    private function bulkDelete(array $ids, int $tenantId): JsonResponse
+    {
+        $deleted = Expense::where('tenant_id', $tenantId)
+            ->whereIn('id', $ids)
+            ->whereIn('status', ['pending', 'rejected'])
+            ->delete();
+
+        return response()->json([
+            'action'  => 'delete',
+            'deleted' => $deleted,
+            'skipped' => count($ids) - $deleted,
+        ]);
+    }
+}

--- a/tests/Feature/ExpenseBulkControllerTest.php
+++ b/tests/Feature/ExpenseBulkControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ExpenseBulkControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+        Sanctum::actingAs($this->user);
+    }
+
+    public function test_bulk_approve_pending_expenses(): void
+    {
+        $expenses = Expense::factory()->count(3)->create([
+            'tenant_id' => 1, 'status' => 'pending',
+        ]);
+
+        $response = $this->postJson('/api/expenses/bulk', [
+            'action' => 'approve',
+            'ids'    => $expenses->pluck('id')->toArray(),
+        ]);
+
+        $response->assertOk();
+        $this->assertEquals(3, $response->json('updated'));
+        $this->assertEquals('approved', Expense::find($expenses->first()->id)->status);
+    }
+
+    public function test_bulk_reject_with_reason(): void
+    {
+        $expenses = Expense::factory()->count(2)->create([
+            'tenant_id' => 1, 'status' => 'pending',
+        ]);
+
+        $response = $this->postJson('/api/expenses/bulk', [
+            'action'           => 'reject',
+            'ids'              => $expenses->pluck('id')->toArray(),
+            'rejection_reason' => 'Missing receipts',
+        ]);
+
+        $response->assertOk();
+        $this->assertEquals(2, $response->json('updated'));
+        $this->assertEquals('Missing receipts', Expense::find($expenses->first()->id)->rejection_reason);
+    }
+
+    public function test_cross_tenant_ids_rejected(): void
+    {
+        $otherExpense = Expense::factory()->create(['tenant_id' => 99, 'status' => 'pending']);
+
+        $response = $this->postJson('/api/expenses/bulk', [
+            'action' => 'approve',
+            'ids'    => [$otherExpense->id],
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertEquals('pending', $otherExpense->fresh()->status);
+    }
+
+    public function test_bulk_delete_only_removes_pending_and_rejected(): void
+    {
+        $pending  = Expense::factory()->create(['tenant_id' => 1, 'status' => 'pending']);
+        $approved = Expense::factory()->create(['tenant_id' => 1, 'status' => 'approved']);
+
+        $this->postJson('/api/expenses/bulk', [
+            'action' => 'delete',
+            'ids'    => [$pending->id, $approved->id],
+        ])->assertOk();
+
+        $this->assertNull(Expense::find($pending->id));
+        $this->assertNotNull(Expense::find($approved->id));
+    }
+
+    public function test_invalid_action_returns_422(): void
+    {
+        $this->postJson('/api/expenses/bulk', [
+            'action' => 'hack',
+            'ids'    => [1],
+        ])->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary

- `ExpenseBulkController` (single-action invokable) accepting `POST /api/expenses/bulk` with `action` and `ids[]`
- Validates all IDs belong to current tenant before any operation; returns 422 on mismatch
- Approve: sets `status=approved`, `approved_by`, `approved_at` for pending-only expenses
- Reject: sets `status=rejected`, `rejection_reason` for pending-only expenses
- Export: dispatches `ExportExpensesCsv` job to `reports` queue; returns 202
- Delete: soft-deletes only pending and rejected expenses (approved protected)
- Capped at 500 IDs per request; 5 PHPUnit feature tests

## Test plan

- [ ] All 5 tests pass
- [ ] Approve only updates `pending` expenses; already-approved are skipped
- [ ] Cross-tenant IDs return 422 and make no changes
- [ ] Delete skips `approved` expenses (returns correct `skipped` count)
- [ ] Invalid action returns 422


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_