### PR TITLE
feat: Terraform VPC with public/private subnets and per-AZ NAT gateways

### DIFF
--- a/terraform/variables_vpc.tf
+++ b/terraform/variables_vpc.tf
@@ -1,0 +1,17 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to use (2 or 3)"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT gateway instead of one per AZ (cheaper for non-prod)"
+  type        = bool
+  default     = false
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,125 @@
+# ── VPC ──────────────────────────────────────────────────────────────────────
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-vpc" })
+}
+
+# ── Internet Gateway ─────────────────────────────────────────────────────────
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = merge(var.common_tags, { Name = "${var.project}-${var.environment}-igw" })
+}
+
+# ── Public Subnets ───────────────────────────────────────────────────────────
+resource "aws_subnet" "public" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index)
+  availability_zone = var.availability_zones[count.index]
+  map_public_ip_on_launch = false
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  })
+}
+
+# ── Private Subnets ───────────────────────────────────────────────────────────
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones))
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  })
+}
+
+# ── Elastic IPs for NAT Gateways ────────────────────────────────────────────────
+resource "aws_eip" "nat" {
+  count  = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  domain = "vpc"
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-nat-eip-${count.index + 1}"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ── NAT Gateways ──────────────────────────────────────────────────────────────
+resource "aws_nat_gateway" "main" {
+  count         = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-nat-${count.index + 1}"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ── Route Tables ──────────────────────────────────────────────────────────────
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project}-${var.environment}-public-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[var.single_nat_gateway ? 0 : count.index].id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project}-${var.environment}-private-rt-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────────
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs (one per AZ)"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs (one per AZ)"
+  value       = aws_subnet.private[*].id
+}
+
+output "nat_gateway_public_ips" {
+  description = "Elastic IP addresses of NAT gateways"
+  value       = aws_eip.nat[*].public_ip
+}


### PR DESCRIPTION
## Summary

- Add `terraform/vpc.tf` and `terraform/variables_vpc.tf`
- VPC with configurable CIDR (default `10.0.0.0/16`), DNS hostnames + resolution enabled
- Internet Gateway attached to VPC
- Public subnets via `cidrsubnet` (offset 0), private subnets (offset + AZ count) — one per AZ
- EIP + NAT Gateway per AZ for HA; `single_nat_gateway = true` variable for cost-savings in non-prod
- Public route table with `0.0.0.0/0 → IGW`; per-AZ private route tables with `0.0.0.0/0 → NAT`
- Outputs: `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `nat_gateway_eips`

## Test plan

- [ ] `terraform plan` produces no errors with default variable values
- [ ] Verify subnet CIDRs do not overlap between public and private
- [ ] Confirm `single_nat_gateway = true` creates exactly one EIP and one NAT gateway
- [ ] Check private subnets route through NAT, public subnets route through IGW
- [ ] Validate outputs are consumed correctly by ECS and Aurora modules

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_