### PR TITLE
feat: WebhookController with HMAC-SHA256 signature verification and replay protection

### DIFF
--- a/app/Events/WebhookReceived.php
+++ b/app/Events/WebhookReceived.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WebhookReceived
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly int $tenantId,
+        public readonly int $endpointId,
+        public readonly string $eventType,
+        public readonly array $payload,
+    ) {}
+}

--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Events\WebhookReceived;
+use App\Models\WebhookEndpoint;
+use App\Models\WebhookLog;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+
+class WebhookController extends Controller
+{
+    private const SIGNATURE_HEADER = 'X-Webhook-Signature';
+    private const TIMESTAMP_HEADER = 'X-Webhook-Timestamp';
+    private const REPLAY_WINDOW_SECONDS = 300;
+
+    public function receive(Request $request, string $endpointId): Response
+    {
+        $endpoint = WebhookEndpoint::where('public_id', $endpointId)
+            ->where('is_active', true)
+            ->firstOrFail();
+
+        $rawBody = $request->getContent();
+
+        if (! $this->verifySignature($request, $endpoint->secret, $rawBody)) {
+            $this->logAttempt($endpoint, $rawBody, 'invalid_signature');
+            return response('Forbidden', 403);
+        }
+
+        if (! $this->verifyTimestamp($request)) {
+            $this->logAttempt($endpoint, $rawBody, 'replay_detected');
+            return response('Request too old', 400);
+        }
+
+        $payload = json_decode($rawBody, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return response('Invalid JSON', 400);
+        }
+
+        $this->logAttempt($endpoint, $rawBody, 'accepted');
+
+        event(new WebhookReceived(
+            tenantId: $endpoint->tenant_id,
+            endpointId: $endpoint->id,
+            eventType: $payload['event'] ?? 'unknown',
+            payload: $payload,
+        ));
+
+        return response('', 200);
+    }
+
+    private function verifySignature(Request $request, string $secret, string $rawBody): bool
+    {
+        $signature = $request->header(self::SIGNATURE_HEADER, '');
+        $timestamp = $request->header(self::TIMESTAMP_HEADER, '');
+
+        if (empty($signature) || empty($timestamp)) {
+            return false;
+        }
+
+        $signedPayload = $timestamp . '.' . $rawBody;
+        $expected = 'sha256=' . hash_hmac('sha256', $signedPayload, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+
+    private function verifyTimestamp(Request $request): bool
+    {
+        $timestamp = (int) $request->header(self::TIMESTAMP_HEADER, 0);
+
+        if ($timestamp === 0) {
+            return false;
+        }
+
+        return abs(time() - $timestamp) <= self::REPLAY_WINDOW_SECONDS;
+    }
+
+    private function logAttempt(WebhookEndpoint $endpoint, string $rawBody, string $status): void
+    {
+        try {
+            WebhookLog::create([
+                'webhook_endpoint_id' => $endpoint->id,
+                'tenant_id' => $endpoint->tenant_id,
+                'payload' => $rawBody,
+                'status' => $status,
+                'received_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('Failed to log webhook attempt', ['error' => $e->getMessage()]);
+        }
+    }
+}

--- a/tests/Feature/WebhookControllerTest.php
+++ b/tests/Feature/WebhookControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\WebhookReceived;
+use App\Models\Tenant;
+use App\Models\WebhookEndpoint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class WebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private WebhookEndpoint $endpoint;
+    private string $secret = 'test-webhook-secret-32-chars-long!';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = Tenant::factory()->create();
+        $this->endpoint = WebhookEndpoint::factory()->create([
+            'tenant_id' => $tenant->id,
+            'secret' => $this->secret,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_accepts_valid_signed_webhook(): void
+    {
+        Event::fake();
+
+        $payload = json_encode(['event' => 'expense.created', 'data' => ['id' => 1]]);
+        $timestamp = (string) time();
+        $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $payload, $this->secret);
+
+        $response = $this->postJson(
+            "/api/webhooks/{$this->endpoint->public_id}",
+            json_decode($payload, true),
+            [
+                'X-Webhook-Signature' => $signature,
+                'X-Webhook-Timestamp' => $timestamp,
+                'Content-Type' => 'application/json',
+            ]
+        );
+
+        $response->assertStatus(200);
+        Event::assertDispatched(WebhookReceived::class);
+    }
+
+    public function test_rejects_invalid_signature(): void
+    {
+        $response = $this->postJson(
+            "/api/webhooks/{$this->endpoint->public_id}",
+            ['event' => 'expense.created'],
+            [
+                'X-Webhook-Signature' => 'sha256=invalidsignature',
+                'X-Webhook-Timestamp' => (string) time(),
+            ]
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_rejects_replay_attack(): void
+    {
+        $payload = json_encode(['event' => 'expense.created']);
+        $oldTimestamp = (string) (time() - 400);
+        $signature = 'sha256=' . hash_hmac('sha256', $oldTimestamp . '.' . $payload, $this->secret);
+
+        $response = $this->postJson(
+            "/api/webhooks/{$this->endpoint->public_id}",
+            json_decode($payload, true),
+            [
+                'X-Webhook-Signature' => $signature,
+                'X-Webhook-Timestamp' => $oldTimestamp,
+            ]
+        );
+
+        $response->assertStatus(400);
+    }
+
+    public function test_returns_404_for_inactive_endpoint(): void
+    {
+        $this->endpoint->update(['is_active' => false]);
+
+        $response = $this->postJson("/api/webhooks/{$this->endpoint->public_id}");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_rejects_missing_signature_headers(): void
+    {
+        $response = $this->postJson(
+            "/api/webhooks/{$this->endpoint->public_id}",
+            ['event' => 'expense.created']
+        );
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `app/Http/Controllers/Api/WebhookController.php` — receives webhook events on public endpoints identified by `public_id`
- HMAC-SHA256 signature: `sha256=HMAC(secret, timestamp.rawBody)` in `X-Webhook-Signature` header, verified with `hash_equals` to prevent timing attacks
- Replay protection: rejects requests where `X-Webhook-Timestamp` is more than 300 seconds old
- Dispatches `WebhookReceived` event for downstream listeners
- Logs every attempt (accepted / invalid_signature / replay_detected) to `webhook_logs` table; log failures are caught silently
- Add `app/Events/WebhookReceived.php` — readonly DTO event carrying tenantId, endpointId, eventType, payload
- Add `tests/Feature/WebhookControllerTest.php` — 5 tests covering valid, invalid signature, replay, inactive endpoint, missing headers

## Test plan

- [ ] Verify valid signed request returns 200 and dispatches `WebhookReceived`
- [ ] Confirm tampered signature returns 403
- [ ] Test timestamp > 300s old returns 400
- [ ] Check inactive endpoint returns 404
- [ ] Validate missing signature/timestamp headers return 403

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_