### PR TITLE
feat: WAFv2 with managed rule groups, IP rate limiting, and auth endpoint protection

### DIFF
--- a/terraform/variables_waf.tf
+++ b/terraform/variables_waf.tf
@@ -1,0 +1,29 @@
+variable "waf_rate_limit_per_ip" {
+  description = "Max requests per IP per 5 minutes before blocking"
+  type        = number
+  default     = 2000
+}
+
+variable "waf_auth_rate_limit" {
+  description = "Max auth endpoint requests per IP per 5 minutes"
+  type        = number
+  default     = 100
+}
+
+variable "waf_max_body_size_bytes" {
+  description = "Max allowed request body size in bytes for non-upload endpoints"
+  type        = number
+  default     = 65536
+}
+
+variable "waf_log_retention_days" {
+  description = "CloudWatch log retention for WAF logs in days"
+  type        = number
+  default     = 90
+}
+
+variable "kms_key_arn_us_east_1" {
+  description = "KMS key ARN in us-east-1 for WAF log encryption"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,0 +1,251 @@
+# WAFv2 must be created in us-east-1 for CloudFront association
+resource "aws_wafv2_web_acl" "main" {
+  provider    = aws.us_east_1
+  name        = "${var.project}-${var.environment}-waf"
+  description = "WAF for ${var.project} CloudFront distribution"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # AWS Managed Rules: Core rule set
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            allow {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules: Known bad inputs
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules: SQL injection
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-sqli"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Custom: IP-based rate limiting per 5-minute window
+  rule {
+    name     = "RateLimitPerIP"
+    priority = 40
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_rate_limit_per_ip
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Custom: Strict rate limiting on auth endpoints
+  rule {
+    name     = "RateLimitAuthEndpoints"
+    priority = 50
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_auth_rate_limit
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          byte_match_statement {
+            search_string         = "/api/auth"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "STARTS_WITH"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-auth-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Custom: Block requests with oversized bodies on upload endpoint
+  rule {
+    name     = "BlockLargeBodyOnNonUpload"
+    priority = 60
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = var.waf_max_body_size_bytes
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "/api/import"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+                positional_constraint = "STARTS_WITH"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-${var.environment}-large-body"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project}-${var.environment}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.common_tags
+}
+
+# CloudWatch log group for WAF logs (must start with aws-waf-logs-)
+resource "aws_cloudwatch_log_group" "waf" {
+  provider          = aws.us_east_1
+  name              = "aws-waf-logs-${var.project}-${var.environment}"
+  retention_in_days = var.waf_log_retention_days
+  kms_key_id        = var.kms_key_arn_us_east_1
+
+  tags = var.common_tags
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "main" {
+  provider                = aws.us_east_1
+  log_destination_configs = [aws_cloudwatch_log_group.waf.arn]
+  resource_arn            = aws_wafv2_web_acl.main.arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}
+
+output "waf_web_acl_arn" {
+  description = "WAFv2 WebACL ARN for CloudFront association"
+  value       = aws_wafv2_web_acl.main.arn
+}
+
+output "waf_web_acl_id" {
+  description = "WAFv2 WebACL ID"
+  value       = aws_wafv2_web_acl.main.id
+}


### PR DESCRIPTION
## Summary

- Add `terraform/waf.tf` and `terraform/variables_waf.tf`
- WAFv2 in `CLOUDFRONT` scope via `aws.us_east_1` provider alias (required for CloudFront)
- AWS Managed Rule Groups: CommonRuleSet (priority 10), KnownBadInputsRuleSet (20), SQLiRuleSet (30) — SizeRestrictions_BODY overridden to allow large CSV uploads on import endpoint
- Custom rate limiting: 2000 req/5min per IP (configurable via `waf_rate_limit_per_ip`); tightened to 100 req/5min on `/api/auth*` paths
- Body size guard: blocks requests > 64 KB except on `/api/import` paths
- WAF logs: CloudWatch log group named `aws-waf-logs-*` (required prefix), log filter keeps only BLOCK actions, KMS-encrypted with us-east-1 CMK
- Outputs: `waf_web_acl_arn` consumed by CloudFront module, `waf_web_acl_id`

## Test plan

- [ ] `terraform plan` succeeds with `provider = aws.us_east_1` alias configured
- [ ] Verify `waf_web_acl_arn` output is wired to `aws_cloudfront_distribution.web_acl_id`
- [ ] Confirm SQL injection test request is blocked by SQLiRuleSet rule
- [ ] Test rate limiter blocks after `waf_rate_limit_per_ip` requests in 5 minutes
- [ ] Validate log group name starts with `aws-waf-logs-` (AWS requirement)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_