### PR TITLE
feat: CloudWatch alarms for ECS, Aurora, ElastiCache, and ALB with SNS notification

### DIFF
--- a/terraform/cloudwatch_alarms.tf
+++ b/terraform/cloudwatch_alarms.tf
@@ -1,0 +1,178 @@
+# ──────────────────────────────────────────────
+# ECS Fargate alarms
+# ──────────────────────────────────────────────
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "${var.project}-${var.environment}-ecs-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.alarm_ecs_cpu_threshold
+  alarm_description   = "ECS CPU utilization exceeded ${var.alarm_ecs_cpu_threshold}% for 2 consecutive minutes"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  ok_actions          = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "${var.project}-${var.environment}-ecs-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.alarm_ecs_memory_threshold
+  alarm_description   = "ECS memory utilization exceeded ${var.alarm_ecs_memory_threshold}%"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  ok_actions          = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+
+  tags = var.common_tags
+}
+
+# ──────────────────────────────────────────────
+# Aurora MySQL alarms
+# ──────────────────────────────────────────────
+resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
+  alarm_name          = "${var.project}-${var.environment}-aurora-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = var.alarm_aurora_connections_threshold
+  alarm_description   = "Aurora connection count exceeds ${var.alarm_aurora_connections_threshold}"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  ok_actions          = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBClusterIdentifier = var.aurora_cluster_identifier
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "aurora_replication_lag" {
+  alarm_name          = "${var.project}-${var.environment}-aurora-replica-lag"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "AuroraReplicaLag"
+  namespace           = "AWS/RDS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = var.alarm_aurora_replica_lag_ms
+  alarm_description   = "Aurora replica lag exceeded ${var.alarm_aurora_replica_lag_ms}ms"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBClusterIdentifier = var.aurora_cluster_identifier
+  }
+
+  tags = var.common_tags
+}
+
+# ──────────────────────────────────────────────
+# ElastiCache Redis alarms
+# ──────────────────────────────────────────────
+resource "aws_cloudwatch_metric_alarm" "redis_evictions" {
+  alarm_name          = "${var.project}-${var.environment}-redis-evictions"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Evictions"
+  namespace           = "AWS/ElastiCache"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alarm_redis_evictions_threshold
+  alarm_description   = "Redis evictions detected — cache may be under-provisioned"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ReplicationGroupId = var.redis_replication_group_id
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_memory_high" {
+  alarm_name          = "${var.project}-${var.environment}-redis-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.alarm_redis_memory_threshold
+  alarm_description   = "Redis memory usage exceeded ${var.alarm_redis_memory_threshold}%"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  ok_actions          = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ReplicationGroupId = var.redis_replication_group_id
+  }
+
+  tags = var.common_tags
+}
+
+# ──────────────────────────────────────────────
+# ALB alarms
+# ──────────────────────────────────────────────
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "${var.project}-${var.environment}-alb-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alarm_alb_5xx_threshold
+  alarm_description   = "ALB 5xx error count exceeded ${var.alarm_alb_5xx_threshold} in 1 minute"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  ok_actions          = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_target_response_time" {
+  alarm_name          = "${var.project}-${var.environment}-alb-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  extended_statistic  = "p95"
+  threshold           = var.alarm_alb_latency_seconds
+  alarm_description   = "ALB p95 latency exceeded ${var.alarm_alb_latency_seconds}s"
+  alarm_actions       = [var.sns_ops_alerts_arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = var.common_tags
+}

--- a/terraform/variables_cloudwatch_alarms.tf
+++ b/terraform/variables_cloudwatch_alarms.tf
@@ -1,0 +1,77 @@
+variable "alarm_ecs_cpu_threshold" {
+  description = "ECS CPU utilization % threshold for alarm"
+  type        = number
+  default     = 80
+}
+
+variable "alarm_ecs_memory_threshold" {
+  description = "ECS memory utilization % threshold for alarm"
+  type        = number
+  default     = 85
+}
+
+variable "alarm_aurora_connections_threshold" {
+  description = "Aurora maximum connection count threshold"
+  type        = number
+  default     = 800
+}
+
+variable "alarm_aurora_replica_lag_ms" {
+  description = "Aurora replica lag threshold in milliseconds"
+  type        = number
+  default     = 1000
+}
+
+variable "alarm_redis_evictions_threshold" {
+  description = "Redis eviction count threshold per minute"
+  type        = number
+  default     = 0
+}
+
+variable "alarm_redis_memory_threshold" {
+  description = "Redis memory usage % threshold"
+  type        = number
+  default     = 80
+}
+
+variable "alarm_alb_5xx_threshold" {
+  description = "ALB 5xx error count per minute threshold"
+  type        = number
+  default     = 10
+}
+
+variable "alarm_alb_latency_seconds" {
+  description = "ALB p95 response time threshold in seconds"
+  type        = number
+  default     = 3
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS cluster name for alarm dimensions"
+  type        = string
+}
+
+variable "ecs_service_name" {
+  description = "ECS service name for alarm dimensions"
+  type        = string
+}
+
+variable "aurora_cluster_identifier" {
+  description = "Aurora DB cluster identifier for alarm dimensions"
+  type        = string
+}
+
+variable "redis_replication_group_id" {
+  description = "ElastiCache replication group ID for alarm dimensions"
+  type        = string
+}
+
+variable "alb_arn_suffix" {
+  description = "ALB ARN suffix for alarm dimensions (e.g. app/my-alb/1234567890)"
+  type        = string
+}
+
+variable "sns_ops_alerts_arn" {
+  description = "SNS topic ARN for operational alerts"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Add `terraform/cloudwatch_alarms.tf` and `terraform/variables_cloudwatch_alarms.tf`
- **ECS**: CPU > 80% and Memory > 85% for 2 consecutive 60s periods → SNS ops-alerts
- **Aurora**: connection count > 800 (3 periods) and replica lag > 1000ms (2 periods) → SNS ops-alerts
- **ElastiCache Redis**: evictions > 0 per minute (any eviction is notable) and memory usage > 80% → SNS ops-alerts
- **ALB**: 5xx count > 10/min and p95 latency > 3s → SNS ops-alerts
- All alarms use `treat_missing_data = notBreaching` to avoid false positives during maintenance
- OK actions send recovery notifications to same SNS topic
- All thresholds configurable via variables; `sns_ops_alerts_arn` wired from existing SNS module output

## Test plan

- [ ] `terraform plan` shows 8 new alarm resources with correct metric names
- [ ] Verify ECS alarm dimensions match cluster/service names from ECS module
- [ ] Confirm Aurora alarm uses `DBClusterIdentifier` (not instance) for cluster-level metrics
- [ ] Check `treat_missing_data = notBreaching` prevents alarm during zero-scale periods
- [ ] Test SNS topic receives notification when manually setting alarm to ALARM state

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_