### PR TITLE
feat: named rate limiters for API, auth, export, and webhook endpoints

### DIFF
--- a/app/Providers/RateLimiterServiceProvider.php
+++ b/app/Providers/RateLimiterServiceProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+
+class RateLimiterServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->configureApiLimiter();
+        $this->configureApiTenantLimiter();
+        $this->configureAuthLimiter();
+        $this->configureExportsLimiter();
+        $this->configureWebhookInvalidLimiter();
+    }
+
+    /**
+     * General API rate limit: 60 req/min per authenticated user.
+     * Falls back to IP for unauthenticated requests.
+     */
+    private function configureApiLimiter(): void
+    {
+        RateLimiter::for('api', function (Request $request) {
+            return $request->user()
+                ? Limit::perMinute(60)->by($request->user()->id)
+                : Limit::perMinute(20)->by($request->ip());
+        });
+    }
+
+    /**
+     * Per-tenant API rate limit: 600 req/min across the whole tenant.
+     * Prevents one tenant from starving others on shared infrastructure.
+     */
+    private function configureApiTenantLimiter(): void
+    {
+        RateLimiter::for('api.tenant', function (Request $request) {
+            $tenantId = $request->user()?->tenant_id;
+
+            if (! $tenantId) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute(600)->by("tenant:{$tenantId}");
+        });
+    }
+
+    /**
+     * Auth endpoints: 5 attempts per minute per IP.
+     * Applies to login, password reset, and 2FA verify.
+     */
+    private function configureAuthLimiter(): void
+    {
+        RateLimiter::for('auth', function (Request $request) {
+            return Limit::perMinute(5)
+                ->by($request->ip())
+                ->response(function () {
+                    return response()->json([
+                        'message' => 'Too many authentication attempts. Please try again later.',
+                    ], 429);
+                });
+        });
+    }
+
+    /**
+     * Export endpoint: 5 exports per 10 minutes per user.
+     * Exports are expensive — queue-based but still guarded.
+     */
+    private function configureExportsLimiter(): void
+    {
+        RateLimiter::for('exports', function (Request $request) {
+            return $request->user()
+                ? Limit::perMinutes(10, 5)->by($request->user()->id)
+                : Limit::perMinutes(10, 1)->by($request->ip());
+        });
+    }
+
+    /**
+     * Webhook invalid-signature backoff: track per endpoint + IP.
+     * After 20 invalid signatures in 5 min, the IP is effectively blocked.
+     */
+    private function configureWebhookInvalidLimiter(): void
+    {
+        RateLimiter::for('webhook.invalid', function (Request $request) {
+            $endpointId = $request->route('endpointId', 'unknown');
+
+            return Limit::perMinutes(5, 20)
+                ->by($request->ip() . ':' . $endpointId);
+        });
+    }
+}

--- a/tests/Unit/RateLimiterServiceProviderTest.php
+++ b/tests/Unit/RateLimiterServiceProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimiterServiceProviderTest extends TestCase
+{
+    public function test_api_limiter_is_registered(): void
+    {
+        $this->assertTrue(RateLimiter::limiter('api') !== null);
+    }
+
+    public function test_auth_limiter_is_registered(): void
+    {
+        $this->assertTrue(RateLimiter::limiter('auth') !== null);
+    }
+
+    public function test_exports_limiter_is_registered(): void
+    {
+        $this->assertTrue(RateLimiter::limiter('exports') !== null);
+    }
+
+    public function test_webhook_invalid_limiter_is_registered(): void
+    {
+        $this->assertTrue(RateLimiter::limiter('webhook.invalid') !== null);
+    }
+
+    public function test_api_tenant_limiter_is_registered(): void
+    {
+        $this->assertTrue(RateLimiter::limiter('api.tenant') !== null);
+    }
+
+    public function test_auth_limiter_returns_429_on_too_many_requests(): void
+    {
+        for ($i = 0; $i < 6; $i++) {
+            $response = $this->postJson('/api/auth/login', [
+                'email'    => 'test@example.com',
+                'password' => 'wrong',
+            ]);
+        }
+
+        $response->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `app/Providers/RateLimiterServiceProvider.php` — 5 named Laravel rate limiters registered in `boot()`
- `api`: 60 req/min per authenticated user; 20 req/min per IP for unauthenticated requests
- `api.tenant`: 600 req/min per tenant to prevent one tenant from starving others; no-ops when unauthenticated
- `auth`: 5 req/min per IP on login/password-reset/2FA endpoints; custom 429 JSON response
- `exports`: 5 exports per 10 minutes per user (queue-based but still guarded); 1/10min for unauthenticated
- `webhook.invalid`: 20 invalid signatures per 5 min per IP+endpointId combo — effectively blocks brute-force key discovery
- Add `tests/Unit/RateLimiterServiceProviderTest.php` — 6 tests verifying all 5 limiters are registered and auth endpoint returns 429 after threshold

## Test plan

- [ ] Verify all 5 limiters appear when iterating `RateLimiter::limiter(name)`
- [ ] Confirm 6th auth request returns 429 with correct JSON body
- [ ] Test `api.tenant` returns `Limit::none()` for unauthenticated requests
- [ ] Check `exports` limiter uses 10-minute window, not per-minute
- [ ] Validate `webhook.invalid` key includes both IP and endpoint ID

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_