### PR TITLE
feat: Department model, migration, CRUD controller with hierarchy support and tenant scoping

### DIFF
--- a/app/Http/Controllers/Api/DepartmentController.php
+++ b/app/Http/Controllers/Api/DepartmentController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Department;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class DepartmentController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $departments = Department::forTenant($tenantId)
+            ->when($request->boolean('active_only', false), fn($q) => $q->active())
+            ->when($request->boolean('tree'), fn($q) => $q->topLevel()->with('children.children'))
+            ->when(! $request->boolean('tree'), fn($q) => $q->with('parent:id,name', 'manager:id,name'))
+            ->withCount('users')
+            ->orderBy('name')
+            ->get();
+
+        return response()->json($departments);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'            => 'required|string|max:100',
+            'code'            => 'nullable|string|max:20',
+            'parent_id'       => 'nullable|integer|exists:departments,id',
+            'manager_user_id' => 'nullable|integer|exists:users,id',
+            'is_active'       => 'boolean',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        if (isset($validated['parent_id'])) {
+            Department::forTenant($tenantId)->findOrFail($validated['parent_id']);
+        }
+
+        if (isset($validated['code'])) {
+            $exists = Department::forTenant($tenantId)
+                ->where('code', $validated['code'])
+                ->exists();
+
+            if ($exists) {
+                return response()->json([
+                    'message' => 'A department with this code already exists.',
+                ], 409);
+            }
+        }
+
+        $department = Department::create(array_merge($validated, [
+            'tenant_id' => $tenantId,
+        ]));
+
+        return response()->json($department->load('parent:id,name', 'manager:id,name'), 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $department = Department::forTenant(Auth::user()->tenant_id)
+            ->with('parent:id,name', 'manager:id,name', 'children:id,name,parent_id')
+            ->withCount('users')
+            ->findOrFail($id);
+
+        return response()->json($department);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+        $department = Department::forTenant($tenantId)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'            => 'sometimes|string|max:100',
+            'code'            => 'nullable|string|max:20',
+            'parent_id'       => 'nullable|integer',
+            'manager_user_id' => 'nullable|integer|exists:users,id',
+            'is_active'       => 'sometimes|boolean',
+        ]);
+
+        if (isset($validated['parent_id']) && $validated['parent_id'] === $id) {
+            return response()->json(['message' => 'A department cannot be its own parent.'], 422);
+        }
+
+        $department->update($validated);
+
+        return response()->json($department->load('parent:id,name', 'manager:id,name'));
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $department = Department::forTenant(Auth::user()->tenant_id)
+            ->withCount('users', 'children')
+            ->findOrFail($id);
+
+        if ($department->users_count > 0) {
+            return response()->json([
+                'message' => 'Cannot delete a department with assigned users.',
+            ], 409);
+        }
+
+        if ($department->children_count > 0) {
+            return response()->json([
+                'message' => 'Cannot delete a department that has sub-departments.',
+            ], 409);
+        }
+
+        $department->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Department extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id',
+        'parent_id',
+        'name',
+        'code',
+        'manager_user_id',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Department::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Department::class, 'parent_id');
+    }
+
+    public function manager(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'manager_user_id');
+    }
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function scopeForTenant(Builder $query, int $tenantId): Builder
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function scopeTopLevel(Builder $query): Builder
+    {
+        return $query->whereNull('parent_id');
+    }
+}

--- a/database/migrations/2024_01_15_000033_create_departments_table.php
+++ b/database/migrations/2024_01_15_000033_create_departments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('departments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('parent_id')->nullable()->index();
+            $table->string('name', 100);
+            $table->string('code', 20)->nullable();
+            $table->unsignedBigInteger('manager_user_id')->nullable();
+            $table->boolean('is_active')->default(true)->index();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->foreign('tenant_id')->references('id')->on('tenants');
+            $table->foreign('parent_id')->references('id')->on('departments')->nullOnDelete();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('department_id')->nullable()->after('tenant_id');
+            $table->foreign('department_id')->references('id')->on('departments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['department_id']);
+            $table->dropColumn('department_id');
+        });
+        Schema::dropIfExists('departments');
+    }
+};

--- a/tests/Feature/DepartmentControllerTest.php
+++ b/tests/Feature/DepartmentControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DepartmentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tenant = Tenant::factory()->create();
+        $this->user = User::factory()->create(['tenant_id' => $this->tenant->id]);
+    }
+
+    public function test_index_returns_tenant_departments(): void
+    {
+        Department::factory()->count(3)->create(['tenant_id' => $this->tenant->id]);
+        Department::factory()->count(2)->create();
+
+        $this->actingAs($this->user)
+            ->getJson('/api/departments')
+            ->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+
+    public function test_store_creates_department(): void
+    {
+        $this->actingAs($this->user)
+            ->postJson('/api/departments', [
+                'name' => '営業部',
+                'code' => 'SALES',
+            ])
+            ->assertStatus(201)
+            ->assertJsonPath('name', '営業部')
+            ->assertJsonPath('code', 'SALES');
+    }
+
+    public function test_store_rejects_duplicate_code(): void
+    {
+        Department::factory()->create(['tenant_id' => $this->tenant->id, 'code' => 'SALES']);
+
+        $this->actingAs($this->user)
+            ->postJson('/api/departments', ['name' => '営業部２', 'code' => 'SALES'])
+            ->assertStatus(409);
+    }
+
+    public function test_update_prevents_self_as_parent(): void
+    {
+        $dept = Department::factory()->create(['tenant_id' => $this->tenant->id]);
+
+        $this->actingAs($this->user)
+            ->putJson("/api/departments/{$dept->id}", ['parent_id' => $dept->id])
+            ->assertStatus(422);
+    }
+
+    public function test_destroy_fails_with_active_users(): void
+    {
+        $dept = Department::factory()->create(['tenant_id' => $this->tenant->id]);
+        User::factory()->create(['tenant_id' => $this->tenant->id, 'department_id' => $dept->id]);
+
+        $this->actingAs($this->user)
+            ->deleteJson("/api/departments/{$dept->id}")
+            ->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `database/migrations/2024_01_15_000033_create_departments_table.php` — departments with self-referential `parent_id`, unique `(tenant_id, code)`, adds `department_id` FK to `users` table
- Add `app/Models/Department.php` — `parent/children/manager/users/expenses` relations; `scopeForTenant`, `scopeActive`, `scopeTopLevel` scopes; SoftDeletes
- Add `app/Http/Controllers/Api/DepartmentController.php`:
  - `index`: supports `?tree=true` for nested `children.children` eager load; `?active_only=true` filter; includes `users_count`
  - `store`: validates parent belongs to same tenant; rejects duplicate code with 409
  - `update`: prevents circular self-parent reference (422)
  - `destroy`: 409 if department has active users or child departments
- Add `tests/Feature/DepartmentControllerTest.php` — 5 feature tests

## Test plan

- [ ] Verify `index` returns only the authenticated user's tenant departments
- [ ] Confirm `?tree=true` returns nested structure with `children`
- [ ] Test duplicate code returns 409
- [ ] Check self-parent update returns 422
- [ ] Validate delete with active users returns 409

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_