### PR TITLE
feat: Project model, migration, and CRUD controller with budget utilization tracking

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Project;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class ProjectController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $projects = Project::forTenant($tenantId)
+            ->when($request->filled('status'), fn($q) => $q->where('status', $request->status))
+            ->when($request->filled('department_id'), fn($q) => $q->where('department_id', $request->integer('department_id')))
+            ->when($request->filled('search'), fn($q) => $q->where(function ($q2) use ($request) {
+                $q2->where('name', 'like', '%' . $request->search . '%')
+                   ->orWhere('code', 'like', '%' . $request->search . '%');
+            }))
+            ->with('department:id,name', 'owner:id,name')
+            ->withCount('expenses')
+            ->orderByDesc('created_at')
+            ->paginate($request->integer('per_page', 20));
+
+        return response()->json($projects);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'            => 'required|string|max:150',
+            'code'            => 'nullable|string|max:30',
+            'description'     => 'nullable|string|max:2000',
+            'status'          => 'in:planning,active,on_hold,completed,cancelled',
+            'department_id'   => 'nullable|integer|exists:departments,id',
+            'owner_user_id'   => 'nullable|integer|exists:users,id',
+            'start_date'      => 'nullable|date',
+            'end_date'        => 'nullable|date|after_or_equal:start_date',
+            'budget_amount'   => 'nullable|numeric|min:0',
+            'budget_currency' => 'nullable|string|size:3',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        if (! empty($validated['code'])) {
+            $exists = Project::forTenant($tenantId)->where('code', $validated['code'])->exists();
+            if ($exists) {
+                return response()->json(['message' => 'A project with this code already exists.'], 409);
+            }
+        }
+
+        $project = Project::create(array_merge($validated, ['tenant_id' => $tenantId]));
+
+        return response()->json($project->load('department:id,name', 'owner:id,name'), 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $project = Project::forTenant(Auth::user()->tenant_id)
+            ->with('department:id,name', 'owner:id,name')
+            ->withCount('expenses')
+            ->findOrFail($id);
+
+        return response()->json(array_merge($project->toArray(), [
+            'spent_amount'        => $project->spent_amount,
+            'budget_utilization'  => $project->budget_utilization,
+        ]));
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $project = Project::forTenant(Auth::user()->tenant_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'            => 'sometimes|string|max:150',
+            'code'            => 'nullable|string|max:30',
+            'description'     => 'nullable|string|max:2000',
+            'status'          => 'sometimes|in:planning,active,on_hold,completed,cancelled',
+            'department_id'   => 'nullable|integer|exists:departments,id',
+            'owner_user_id'   => 'nullable|integer|exists:users,id',
+            'start_date'      => 'nullable|date',
+            'end_date'        => 'nullable|date|after_or_equal:start_date',
+            'budget_amount'   => 'nullable|numeric|min:0',
+            'budget_currency' => 'nullable|string|size:3',
+        ]);
+
+        $project->update($validated);
+
+        return response()->json($project->load('department:id,name', 'owner:id,name'));
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $project = Project::forTenant(Auth::user()->tenant_id)
+            ->withCount('expenses')
+            ->findOrFail($id);
+
+        if ($project->expenses_count > 0) {
+            return response()->json(['message' => 'Cannot delete a project with linked expenses.'], 409);
+        }
+
+        $project->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Project extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'department_id', 'owner_user_id',
+        'name', 'code', 'description', 'status',
+        'start_date', 'end_date', 'budget_amount', 'budget_currency',
+    ];
+
+    protected $casts = [
+        'start_date'    => 'date',
+        'end_date'      => 'date',
+        'budget_amount' => 'decimal:2',
+    ];
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function department(): BelongsTo
+    {
+        return $this->belongsTo(Department::class);
+    }
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_user_id');
+    }
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function scopeForTenant(Builder $query, int $tenantId): Builder
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', 'active');
+    }
+
+    public function getSpentAmountAttribute(): float
+    {
+        return (float) $this->expenses()
+            ->whereIn('status', ['approved'])
+            ->sum('amount');
+    }
+
+    public function getBudgetUtilizationAttribute(): float|null
+    {
+        if (! $this->budget_amount || $this->budget_amount == 0) {
+            return null;
+        }
+        return round(($this->spent_amount / $this->budget_amount) * 100, 1);
+    }
+}

--- a/database/migrations/2024_01_15_000034_create_projects_table.php
+++ b/database/migrations/2024_01_15_000034_create_projects_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->unsignedBigInteger('owner_user_id')->nullable();
+            $table->string('name', 150);
+            $table->string('code', 30)->nullable();
+            $table->text('description')->nullable();
+            $table->enum('status', ['planning', 'active', 'on_hold', 'completed', 'cancelled'])
+                ->default('planning')->index();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->decimal('budget_amount', 15, 2)->nullable();
+            $table->string('budget_currency', 3)->default('JPY');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->foreign('tenant_id')->references('id')->on('tenants');
+            $table->foreign('department_id')->references('id')->on('departments')->nullOnDelete();
+        });
+
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->unsignedBigInteger('project_id')->nullable()->after('department_id')->index();
+            $table->foreign('project_id')->references('id')->on('projects')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropForeign(['project_id']);
+            $table->dropColumn('project_id');
+        });
+        Schema::dropIfExists('projects');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `database/migrations/2024_01_15_000034_create_projects_table.php` — projects with status enum (planning/active/on_hold/completed/cancelled), optional budget_amount, unique `(tenant_id, code)`, adds `project_id` FK to expenses table
- Add `app/Models/Project.php` — `spent_amount` (sum of approved expenses) and `budget_utilization` (%) computed attributes; `scopeForTenant`, `scopeActive` scopes; SoftDeletes
- Add `app/Http/Controllers/Api/ProjectController.php`:
  - `index`: filters by status, department_id, search (name/code); includes `expenses_count`
  - `store`: duplicate code guard (409); tenant-scoped creation
  - `show`: returns `spent_amount` + `budget_utilization` in response
  - `update`: validates `end_date >= start_date`
  - `destroy`: 409 if project has linked expenses

## Test plan

- [ ] Verify `index` filters by `?status=active` correctly
- [ ] Confirm duplicate `code` returns 409
- [ ] Test `show` includes `spent_amount` and `budget_utilization` fields
- [ ] Check `end_date` before `start_date` returns 422
- [ ] Validate destroy with linked expenses returns 409

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_