### PR TITLE
feat: ExpenseComment model, migration, and CRUD controller with internal comment support

### DIFF
--- a/app/Http/Controllers/Api/ExpenseCommentController.php
+++ b/app/Http/Controllers/Api/ExpenseCommentController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Expense;
+use App\Models\ExpenseComment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class ExpenseCommentController extends Controller
+{
+    public function index(int $expenseId): JsonResponse
+    {
+        $user = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $expense = Expense::where('tenant_id', $tenantId)->findOrFail($expenseId);
+
+        $comments = ExpenseComment::where('expense_id', $expense->id)
+            ->forTenant($tenantId)
+            ->when(! $user->hasRole('manager'), fn($q) => $q->public())
+            ->with('user:id,name')
+            ->latest()
+            ->get();
+
+        return response()->json($comments);
+    }
+
+    public function store(Request $request, int $expenseId): JsonResponse
+    {
+        $user = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $expense = Expense::where('tenant_id', $tenantId)->findOrFail($expenseId);
+
+        $validated = $request->validate([
+            'body'        => 'required|string|max:2000',
+            'is_internal' => 'boolean',
+        ]);
+
+        $isInternal = ($validated['is_internal'] ?? false) && $user->hasRole('manager');
+
+        $comment = ExpenseComment::create([
+            'expense_id'  => $expense->id,
+            'user_id'     => $user->id,
+            'tenant_id'   => $tenantId,
+            'body'        => $validated['body'],
+            'is_internal' => $isInternal,
+        ]);
+
+        return response()->json($comment->load('user:id,name'), 201);
+    }
+
+    public function update(Request $request, int $expenseId, int $commentId): JsonResponse
+    {
+        $user = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $comment = ExpenseComment::where('expense_id', $expenseId)
+            ->where('user_id', $user->id)
+            ->forTenant($tenantId)
+            ->findOrFail($commentId);
+
+        $validated = $request->validate(['body' => 'required|string|max:2000']);
+
+        $comment->update($validated);
+
+        return response()->json($comment->load('user:id,name'));
+    }
+
+    public function destroy(int $expenseId, int $commentId): JsonResponse
+    {
+        $user = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $comment = ExpenseComment::where('expense_id', $expenseId)
+            ->forTenant($tenantId)
+            ->where(function ($q) use ($user) {
+                $q->where('user_id', $user->id)
+                  ->orWhere(fn($q2) => $q2->whereRaw('? = 1', [$user->hasRole('admin') ? 1 : 0]));
+            })
+            ->findOrFail($commentId);
+
+        $comment->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/ExpenseComment.php
+++ b/app/Models/ExpenseComment.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ExpenseComment extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = ['expense_id', 'user_id', 'tenant_id', 'body', 'is_internal'];
+
+    protected $casts = ['is_internal' => 'boolean'];
+
+    public function expense(): BelongsTo
+    {
+        return $this->belongsTo(Expense::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeForTenant(Builder $query, int $tenantId): Builder
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function scopePublic(Builder $query): Builder
+    {
+        return $query->where('is_internal', false);
+    }
+}

--- a/database/migrations/2024_01_15_000035_create_expense_comments_table.php
+++ b/database/migrations/2024_01_15_000035_create_expense_comments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expense_comments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('expense_id')->index();
+            $table->unsignedBigInteger('user_id')->index();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->text('body');
+            $table->boolean('is_internal')->default(false);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('expense_id')->references('id')->on('expenses')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('tenant_id')->references('id')->on('tenants');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_comments');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `database/migrations/2024_01_15_000035_create_expense_comments_table.php` — `expense_comments` with `is_internal` flag, cascading delete on expense, tenant_id scoping, SoftDeletes
- Add `app/Models/ExpenseComment.php` — `scopeForTenant`, `scopePublic`; belongs to `expense` and `user`
- Add `app/Http/Controllers/Api/ExpenseCommentController.php`:
  - `index`: returns public comments for non-managers; internal comments visible only to managers
  - `store`: creates comment; `is_internal` flag only honored if user `hasRole('manager')`
  - `update`: author-only edit (matched by `user_id`)
  - `destroy`: author can delete own; admins can delete any comment in the tenant

## Test plan

- [ ] Verify `index` hides internal comments from non-manager users
- [ ] Confirm `is_internal=true` is ignored unless user is a manager
- [ ] Test `update` returns 404 when non-author tries to edit
- [ ] Check cascading delete removes comments when expense is deleted
- [ ] Validate cross-tenant comment access returns 404

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_