### PR TITLE
feat: ECR repository with KMS encryption, scan-on-push, lifecycle policy, and OIDC permissions

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,127 @@
+resource "aws_ecr_repository" "app" {
+  name                 = "${var.project}-${var.environment}-app"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key_arn
+  }
+
+  tags = var.common_tags
+}
+
+# Lifecycle policy: keep last N tagged images + clean untagged after 1 day
+resource "aws_ecr_lifecycle_policy" "app" {
+  repository = aws_ecr_repository.app.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last ${var.ecr_keep_image_count} tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["sha-", "v", "release-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = var.ecr_keep_image_count
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+# Repository policy: allow GitHub Actions OIDC role to push
+data "aws_iam_policy_document" "ecr_push" {
+  statement {
+    sid    = "AllowGitHubActionsOIDCPush"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.github_actions_role_arn]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+  }
+
+  statement {
+    sid    = "AllowECSTaskPull"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.ecs_task_execution_role_arn]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "app" {
+  repository = aws_ecr_repository.app.name
+  policy     = data.aws_iam_policy_document.ecr_push.json
+}
+
+# EventBridge rule to alert on HIGH/CRITICAL scan findings
+resource "aws_cloudwatch_event_rule" "ecr_scan_findings" {
+  name        = "${var.project}-${var.environment}-ecr-scan-findings"
+  description = "Alert on HIGH/CRITICAL ECR image scan findings"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ecr"]
+    detail-type = ["ECR Image Scan"]
+    detail = {
+      repository-name   = [aws_ecr_repository.app.name]
+      scan-status       = ["COMPLETE"]
+      finding-severity-counts = {
+        HIGH     = [{ exists = true }]
+      }
+    }
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudwatch_event_target" "ecr_scan_sns" {
+  rule      = aws_cloudwatch_event_rule.ecr_scan_findings.name
+  target_id = "ECRScanFindingsToSNS"
+  arn       = var.sns_ops_alerts_arn
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL for Docker push"
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "ecr_repository_arn" {
+  description = "ECR repository ARN"
+  value       = aws_ecr_repository.app.arn
+}

--- a/terraform/variables_ecr.tf
+++ b/terraform/variables_ecr.tf
@@ -1,0 +1,15 @@
+variable "ecr_keep_image_count" {
+  description = "Number of tagged images to retain in ECR (older images are expired)"
+  type        = number
+  default     = 20
+}
+
+variable "github_actions_role_arn" {
+  description = "IAM role ARN assumed by GitHub Actions OIDC for ECR push"
+  type        = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "ECS task execution role ARN allowed to pull from ECR"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- KMS-encrypted ECR repository with `scan_on_push = true` and `MUTABLE` image tags
- Lifecycle policy: untagged images expire after 1 day (priority 1); keep last 20 tagged images with `sha-`/`v`/`release-` prefix (priority 2)
- Repository policy grants GitHub Actions OIDC role push access and ECS task execution role pull access
- EventBridge rule fires on HIGH severity scan findings → SNS `ops-alerts` topic

## Security

- KMS encryption on all stored images
- Automated vulnerability scanning on every push
- OIDC keyless auth for CI/CD — no long-lived credentials stored
- Scan finding alerts routed to ops channel for immediate action

## Test plan

- [ ] `terraform plan` shows no errors
- [ ] Push image via OIDC role; confirm no credential errors
- [ ] Push untagged image; verify lifecycle expires it within 1 day
- [ ] Trigger HIGH scan finding; verify SNS notification fires

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_