### PR TITLE
feat: Notification center with read/unread management and paginated listing

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'unread_only' => 'boolean',
+            'type'        => 'nullable|string|max:255',
+            'per_page'    => 'integer|min:1|max:100',
+        ]);
+
+        $user  = Auth::user();
+        $query = $user->notifications();
+
+        if ($request->boolean('unread_only')) {
+            $query->whereNull('read_at');
+        }
+
+        if ($request->filled('type')) {
+            $query->where('type', $request->input('type'));
+        }
+
+        $perPage       = (int) $request->input('per_page', 20);
+        $notifications = $query->latest()->paginate($perPage);
+
+        return response()->json([
+            'data' => $notifications->items(),
+            'meta' => [
+                'current_page' => $notifications->currentPage(),
+                'last_page'    => $notifications->lastPage(),
+                'total'        => $notifications->total(),
+                'unread_count' => $user->unreadNotifications()->count(),
+            ],
+        ]);
+    }
+
+    public function show(string $id): JsonResponse
+    {
+        $notification = Auth::user()->notifications()->findOrFail($id);
+
+        return response()->json(['data' => $notification]);
+    }
+
+    public function markAsRead(string $id): JsonResponse
+    {
+        $notification = Auth::user()->notifications()->findOrFail($id);
+        $notification->markAsRead();
+
+        return response()->json(['data' => $notification]);
+    }
+
+    public function markAllAsRead(): JsonResponse
+    {
+        $user = Auth::user();
+        $count = $user->unreadNotifications()->count();
+        $user->unreadNotifications->markAsRead();
+
+        return response()->json([
+            'message'      => 'All notifications marked as read',
+            'marked_count' => $count,
+        ]);
+    }
+
+    public function destroy(string $id): JsonResponse
+    {
+        $notification = Auth::user()->notifications()->findOrFail($id);
+        $notification->delete();
+
+        return response()->json(null, 204);
+    }
+
+    public function destroyRead(): JsonResponse
+    {
+        $user  = Auth::user();
+        $count = $user->readNotifications()->count();
+        $user->readNotifications()->delete();
+
+        return response()->json([
+            'message'       => 'Read notifications deleted',
+            'deleted_count' => $count,
+        ]);
+    }
+
+    public function unreadCount(): JsonResponse
+    {
+        return response()->json([
+            'unread_count' => Auth::user()->unreadNotifications()->count(),
+        ]);
+    }
+}

--- a/tests/Feature/NotificationControllerTest.php
+++ b/tests/Feature/NotificationControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class NotificationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+        $this->actingAs($this->user);
+    }
+
+    public function test_index_returns_paginated_notifications(): void
+    {
+        DatabaseNotification::insert([
+            [
+                'id'              => Str::uuid(),
+                'type'            => 'App\\Notifications\\ExpenseApproved',
+                'notifiable_type' => User::class,
+                'notifiable_id'   => $this->user->id,
+                'data'            => json_encode(['message' => 'Expense approved']),
+                'read_at'         => null,
+                'created_at'      => now(),
+                'updated_at'      => now(),
+            ],
+        ]);
+
+        $this->getJson('/api/notifications')
+            ->assertOk()
+            ->assertJsonStructure(['data', 'meta' => ['current_page', 'last_page', 'total', 'unread_count']]);
+    }
+
+    public function test_unread_only_filter(): void
+    {
+        $readId   = Str::uuid();
+        $unreadId = Str::uuid();
+
+        DatabaseNotification::insert([
+            [
+                'id'              => $readId,
+                'type'            => 'App\\Notifications\\Test',
+                'notifiable_type' => User::class,
+                'notifiable_id'   => $this->user->id,
+                'data'            => json_encode([]),
+                'read_at'         => now(),
+                'created_at'      => now(),
+                'updated_at'      => now(),
+            ],
+            [
+                'id'              => $unreadId,
+                'type'            => 'App\\Notifications\\Test',
+                'notifiable_type' => User::class,
+                'notifiable_id'   => $this->user->id,
+                'data'            => json_encode([]),
+                'read_at'         => null,
+                'created_at'      => now(),
+                'updated_at'      => now(),
+            ],
+        ]);
+
+        $response = $this->getJson('/api/notifications?unread_only=1')->assertOk();
+        $this->assertCount(1, $response->json('data'));
+    }
+
+    public function test_mark_as_read(): void
+    {
+        $id = Str::uuid();
+        DatabaseNotification::insert([[
+            'id'              => $id,
+            'type'            => 'App\\Notifications\\Test',
+            'notifiable_type' => User::class,
+            'notifiable_id'   => $this->user->id,
+            'data'            => json_encode([]),
+            'read_at'         => null,
+            'created_at'      => now(),
+            'updated_at'      => now(),
+        ]]);
+
+        $this->patchJson("/api/notifications/{$id}/read")->assertOk();
+        $this->assertNotNull(DatabaseNotification::find($id)->read_at);
+    }
+
+    public function test_mark_all_as_read(): void
+    {
+        DatabaseNotification::insert([[
+            'id'              => Str::uuid(),
+            'type'            => 'App\\Notifications\\Test',
+            'notifiable_type' => User::class,
+            'notifiable_id'   => $this->user->id,
+            'data'            => json_encode([]),
+            'read_at'         => null,
+            'created_at'      => now(),
+            'updated_at'      => now(),
+        ]]);
+
+        $this->postJson('/api/notifications/read-all')
+            ->assertOk()
+            ->assertJsonPath('marked_count', 1);
+    }
+
+    public function test_destroy_deletes_notification(): void
+    {
+        $id = Str::uuid();
+        DatabaseNotification::insert([[
+            'id'              => $id,
+            'type'            => 'App\\Notifications\\Test',
+            'notifiable_type' => User::class,
+            'notifiable_id'   => $this->user->id,
+            'data'            => json_encode([]),
+            'read_at'         => null,
+            'created_at'      => now(),
+            'updated_at'      => now(),
+        ]]);
+
+        $this->deleteJson("/api/notifications/{$id}")->assertNoContent();
+        $this->assertNull(DatabaseNotification::find($id));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `NotificationController` for in-app notification management
- `index`: paginated listing with `unread_only` and `type` filters; includes `unread_count` in meta
- `markAsRead`: marks single notification read; `markAllAsRead`: bulk mark-read with count response
- `destroy`: deletes single notification; `destroyRead`: bulk-deletes all read notifications
- `unreadCount`: lightweight polling endpoint for notification badge

## Test coverage (5 feature tests)

- Paginated index returns correct structure
- `unread_only=1` filter excludes read notifications
- `markAsRead` sets `read_at` timestamp
- `markAllAsRead` returns correct count
- `destroy` removes notification from database

## Test plan

- [ ] Poll `/api/notifications/unread-count` and verify badge updates
- [ ] Filter with `?unread_only=1` and confirm read notifications excluded
- [ ] Mark all as read; confirm count drops to 0
- [ ] Delete single notification; confirm 204 and gone from DB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_