### PR TITLE
feat: Lambda report generator Terraform module with EventBridge scheduler and KMS S3 output

### DIFF
--- a/terraform/lambda_report.tf
+++ b/terraform/lambda_report.tf
@@ -1,0 +1,197 @@
+# ---------------------------------------------------------------------------
+# Lambda — async report generation triggered by EventBridge or SQS
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_report" {
+  name               = "${var.project}-${var.environment}-lambda-report"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "lambda_report_policy" {
+  statement {
+    sid     = "Logs"
+    actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.project}-${var.environment}-report-generator:*"]
+  }
+
+  statement {
+    sid       = "S3Write"
+    actions   = ["s3:PutObject", "s3:GetObject"]
+    resources = ["${aws_s3_bucket.reports.arn}/*"]
+  }
+
+  statement {
+    sid       = "KMS"
+    actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
+    resources = [aws_kms_key.s3.arn]
+  }
+
+  statement {
+    sid       = "SSM"
+    actions   = ["ssm:GetParameter", "ssm:GetParametersByPath"]
+    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.project}/${var.environment}/*"]
+  }
+
+  statement {
+    sid       = "SES"
+    actions   = ["ses:SendEmail", "ses:SendRawEmail"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+      values   = [var.ses_from_address]
+    }
+  }
+
+  statement {
+    sid       = "VPC"
+    actions   = ["ec2:CreateNetworkInterface", "ec2:DescribeNetworkInterfaces", "ec2:DeleteNetworkInterface"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_report" {
+  name   = "${var.project}-${var.environment}-lambda-report-policy"
+  policy = data.aws_iam_policy_document.lambda_report_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_report" {
+  role       = aws_iam_role.lambda_report.name
+  policy_arn = aws_iam_policy.lambda_report.arn
+}
+
+resource "aws_s3_bucket" "reports" {
+  bucket        = "${var.project}-${var.environment}-reports-${data.aws_caller_identity.current.account_id}"
+  force_destroy = var.environment != "production"
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "reports" {
+  bucket = aws_s3_bucket.reports.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "reports" {
+  bucket = aws_s3_bucket.reports.id
+
+  rule {
+    id     = "expire-old-reports"
+    status = "Enabled"
+
+    expiration {
+      days = var.report_s3_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "reports" {
+  bucket                  = aws_s3_bucket.reports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_lambda_function" "report_generator" {
+  function_name = "${var.project}-${var.environment}-report-generator"
+  role          = aws_iam_role.lambda_report.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.app.repository_url}:lambda-report-latest"
+
+  memory_size = var.lambda_report_memory_mb
+  timeout     = var.lambda_report_timeout_seconds
+
+  environment {
+    variables = {
+      APP_ENV        = var.environment
+      S3_BUCKET      = aws_s3_bucket.reports.bucket
+      SSM_PREFIX     = "/${var.project}/${var.environment}"
+      DB_SSM_KEY     = "/${var.project}/${var.environment}/DB_PASSWORD"
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = aws_subnet.private[*].id
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  tags = local.common_tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_report]
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "${var.project}-${var.environment}-lambda-sg"
+  description = "Lambda report generator outbound to Aurora and S3"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}-lambda-sg" })
+}
+
+# EventBridge rule: trigger report generation on schedule or custom event
+resource "aws_cloudwatch_event_rule" "report_scheduler" {
+  name                = "${var.project}-${var.environment}-scheduled-reports"
+  description         = "Trigger monthly summary report generation on the 1st of each month at 06:00 JST"
+  schedule_expression = "cron(0 21 L * ? *)" # 21:00 UTC = 06:00 JST next day (1st)
+  state               = var.scheduled_reports_enabled ? "ENABLED" : "DISABLED"
+}
+
+resource "aws_cloudwatch_event_target" "report_lambda" {
+  rule = aws_cloudwatch_event_rule.report_scheduler.name
+  arn  = aws_lambda_function.report_generator.arn
+  input = jsonencode({
+    report_type = "monthly_summary"
+    format      = "xlsx"
+    notify_admins = true
+  })
+}
+
+resource "aws_lambda_permission" "eventbridge_invoke" {
+  statement_id  = "AllowEventBridgeInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.report_generator.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.report_scheduler.arn
+}
+
+resource "aws_lambda_function_event_invoke_config" "report_generator" {
+  function_name          = aws_lambda_function.report_generator.function_name
+  maximum_retry_attempts = 1
+
+  destination_config {
+    on_failure {
+      destination = aws_sns_topic.ops_alerts.arn
+    }
+  }
+}

--- a/terraform/variables_lambda_report.tf
+++ b/terraform/variables_lambda_report.tf
@@ -1,0 +1,28 @@
+variable "lambda_report_memory_mb" {
+  description = "Memory in MB allocated to the report generator Lambda"
+  type        = number
+  default     = 1024
+}
+
+variable "lambda_report_timeout_seconds" {
+  description = "Maximum execution time for the report generator Lambda in seconds"
+  type        = number
+  default     = 900
+}
+
+variable "report_s3_retention_days" {
+  description = "Days before generated reports are automatically deleted from S3"
+  type        = number
+  default     = 90
+}
+
+variable "scheduled_reports_enabled" {
+  description = "Whether the monthly scheduled report EventBridge rule is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "ses_from_address" {
+  description = "SES sender address used by the report generator Lambda for notifications"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Terraform module for Lambda-based async report generation
- Dedicated IAM role with least-privilege: CloudWatch Logs, S3 PutObject/GetObject, KMS, SSM GetParameter, SES SendEmail, VPC networking
- KMS-encrypted S3 bucket for report output with 90-day lifecycle expiration
- Lambda deployed from ECR container image (`lambda-report-latest` tag)
- VPC-attached Lambda (private subnets) with dedicated security group for Aurora + S3 access
- EventBridge rule: monthly summary report on 1st of each month at 06:00 JST (cron `0 21 L * ? *`)
- `on_failure` destination → SNS ops-alerts; retry = 1

## Security

- S3 reports bucket: all public access blocked, KMS SSE, `bucket_key_enabled = true`
- SES condition restricts Lambda to send only from `ses_from_address`
- SSM parameter prefix scoped to `/{project}/{environment}/*`

## Variables

| Variable | Default |
|---|---|
| `lambda_report_memory_mb` | 1024 |
| `lambda_report_timeout_seconds` | 900 |
| `report_s3_retention_days` | 90 |
| `scheduled_reports_enabled` | true |

## Test plan

- [ ] `terraform plan` — no errors
- [ ] Invoke Lambda manually with `{"report_type":"monthly_summary"}`
- [ ] Confirm report object written to S3 with KMS encryption
- [ ] Disable `scheduled_reports_enabled = false`; verify EventBridge rule is DISABLED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_