### PR TITLE
feat: Vendor controller with spend stats, duplicate code detection, and soft delete protection

### DIFF
--- a/app/Http/Controllers/Api/VendorController.php
+++ b/app/Http/Controllers/Api/VendorController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\Vendor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class VendorController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'search'   => 'nullable|string|max:100',
+            'status'   => 'nullable|in:active,inactive,blocked',
+            'category' => 'nullable|string|max:80',
+            'per_page' => 'integer|min:1|max:100',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        $query = Vendor::forTenant($tenantId)->orderBy('name');
+
+        if ($request->filled('search')) {
+            $q = $request->input('search');
+            $query->where(fn ($q2) => $q2
+                ->where('name', 'like', "%{$q}%")
+                ->orWhere('code', 'like', "%{$q}%")
+                ->orWhere('email', 'like', "%{$q}%")
+            );
+        }
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->input('status'));
+        }
+
+        if ($request->filled('category')) {
+            $query->where('category', $request->input('category'));
+        }
+
+        $vendors = $query->paginate((int) $request->input('per_page', 24));
+
+        return response()->json([
+            'data' => $vendors->items(),
+            'meta' => [
+                'current_page' => $vendors->currentPage(),
+                'last_page'    => $vendors->lastPage(),
+                'total'        => $vendors->total(),
+            ],
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $validated = $request->validate([
+            'name'     => 'required|string|max:150',
+            'code'     => ['nullable', 'string', 'max:32',
+                           Rule::unique('vendors')->where('tenant_id', $tenantId)->whereNull('deleted_at')],
+            'email'    => 'nullable|email|max:150',
+            'phone'    => 'nullable|string|max:32',
+            'website'  => 'nullable|url|max:255',
+            'tax_id'   => 'nullable|string|max:64',
+            'currency' => 'nullable|string|size:3',
+            'status'   => 'nullable|in:active,inactive,blocked',
+            'category' => 'nullable|string|max:80',
+            'notes'    => 'nullable|string|max:2000',
+        ]);
+
+        $vendor = Vendor::create(array_merge($validated, ['tenant_id' => $tenantId]));
+
+        AuditLog::record('vendor.created', 'Vendor', $vendor->id);
+
+        return response()->json(['data' => $vendor], 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $vendor = Vendor::forTenant(Auth::user()->tenant_id)->findOrFail($id);
+
+        return response()->json([
+            'data' => array_merge($vendor->toArray(), ['spend_stats' => $vendor->spend_stats]),
+        ]);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+        $vendor   = Vendor::forTenant($tenantId)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'     => 'sometimes|string|max:150',
+            'code'     => ['nullable', 'string', 'max:32',
+                           Rule::unique('vendors')->where('tenant_id', $tenantId)->whereNull('deleted_at')->ignore($id)],
+            'email'    => 'nullable|email|max:150',
+            'phone'    => 'nullable|string|max:32',
+            'website'  => 'nullable|url|max:255',
+            'tax_id'   => 'nullable|string|max:64',
+            'currency' => 'nullable|string|size:3',
+            'status'   => 'nullable|in:active,inactive,blocked',
+            'category' => 'nullable|string|max:80',
+            'notes'    => 'nullable|string|max:2000',
+        ]);
+
+        $vendor->update($validated);
+        AuditLog::record('vendor.updated', 'Vendor', $id);
+
+        return response()->json(['data' => $vendor->fresh()]);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+        $vendor   = Vendor::forTenant($tenantId)->withCount('expenses')->findOrFail($id);
+
+        if ($vendor->expenses_count > 0) {
+            return response()->json(['message' => '経費が紐付いているため削除できません。無効化を利用してください。'], 409);
+        }
+
+        $vendor->delete();
+        AuditLog::record('vendor.deleted', 'Vendor', $id);
+
+        return response()->json(null, 204);
+    }
+
+    public function categories(): JsonResponse
+    {
+        $categories = Vendor::forTenant(Auth::user()->tenant_id)
+            ->whereNotNull('category')
+            ->distinct()
+            ->orderBy('category')
+            ->pluck('category');
+
+        return response()->json(['data' => $categories]);
+    }
+}

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Vendor extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'name', 'code', 'email', 'phone', 'website',
+        'tax_id', 'currency', 'status', 'category', 'notes',
+    ];
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function scopeForTenant($query, int $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    public function getSpendStatsAttribute(): array
+    {
+        $stats = $this->expenses()
+            ->selectRaw('COUNT(*) as total_count, SUM(amount) as total_amount, MAX(expense_date) as last_expense_date')
+            ->first();
+
+        return [
+            'total_count'       => (int) ($stats->total_count ?? 0),
+            'total_amount'      => (int) ($stats->total_amount ?? 0),
+            'last_expense_date' => $stats->last_expense_date,
+        ];
+    }
+}

--- a/database/migrations/2024_01_15_000039_create_vendors_table.php
+++ b/database/migrations/2024_01_15_000039_create_vendors_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vendors', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name');
+            $table->string('code', 32)->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone', 32)->nullable();
+            $table->string('website')->nullable();
+            $table->string('tax_id', 64)->nullable();
+            $table->string('currency', 3)->default('JPY');
+            $table->enum('status', ['active', 'inactive', 'blocked'])->default('active');
+            $table->string('category')->nullable();
+            $table->text('notes')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->index(['tenant_id', 'status']);
+            $table->index(['tenant_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vendors');
+    }
+};

--- a/tests/Feature/VendorControllerTest.php
+++ b/tests/Feature/VendorControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VendorControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+        $this->actingAs($this->user);
+    }
+
+    public function test_index_returns_only_tenant_vendors(): void
+    {
+        Vendor::factory()->create(['tenant_id' => 1, 'name' => 'Vendor A']);
+        Vendor::factory()->create(['tenant_id' => 99, 'name' => 'Other Tenant']);
+
+        $response = $this->getJson('/api/vendors')->assertOk();
+        $this->assertCount(1, $response->json('data'));
+    }
+
+    public function test_search_filters_by_name(): void
+    {
+        Vendor::factory()->create(['tenant_id' => 1, 'name' => 'Acme Corp']);
+        Vendor::factory()->create(['tenant_id' => 1, 'name' => 'Beta LLC']);
+
+        $response = $this->getJson('/api/vendors?search=Acme')->assertOk();
+        $this->assertCount(1, $response->json('data'));
+    }
+
+    public function test_store_creates_vendor(): void
+    {
+        $this->postJson('/api/vendors', [
+            'name'     => 'Test Vendor',
+            'email'    => 'vendor@example.com',
+            'currency' => 'JPY',
+        ])->assertCreated()->assertJsonPath('data.name', 'Test Vendor');
+    }
+
+    public function test_duplicate_code_returns_422(): void
+    {
+        Vendor::factory()->create(['tenant_id' => 1, 'code' => 'VEND001']);
+
+        $this->postJson('/api/vendors', [
+            'name' => 'Duplicate',
+            'code' => 'VEND001',
+        ])->assertUnprocessable();
+    }
+
+    public function test_destroy_blocked_when_has_expenses(): void
+    {
+        $vendor = Vendor::factory()->create(['tenant_id' => 1]);
+        // Simulate has expenses via withCount
+        $vendor->expenses()->create([
+            'tenant_id' => 1, 'user_id' => $this->user->id,
+            'title' => 'Test', 'amount' => 1000, 'currency' => 'JPY',
+            'category_id' => 1, 'expense_date' => now(), 'status' => 'draft',
+        ]);
+
+        $this->deleteJson("/api/vendors/{$vendor->id}")->assertConflict();
+    }
+
+    public function test_cross_tenant_returns_404(): void
+    {
+        $other = Vendor::factory()->create(['tenant_id' => 99]);
+        $this->getJson("/api/vendors/{$other->id}")->assertNotFound();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Vendor` model + migration + `VendorController` + 6 feature tests
- `index`: search (name/code/email), filter by status/category, paginated 24/page; tenant-scoped
- `show`: returns model + computed `spend_stats` (total_count, total_amount, last_expense_date)
- `destroy`: blocked with 409 when vendor has expenses; soft delete otherwise
- `categories()`: returns distinct category list for filter dropdown
- `AuditLog::record()` called on create/update/delete

## Uniqueness

- `(tenant_id, code)` unique; duplicate code returns 422
- Cross-tenant access returns 404

## Tests (6 feature tests)

- Index returns only tenant's vendors
- Search filters by name
- Store creates vendor
- Duplicate code → 422
- Destroy blocked when expenses exist → 409
- Cross-tenant → 404

## Test plan

- [ ] Create vendor; confirm in list
- [ ] Attempt duplicate code → 422
- [ ] Add expense to vendor; try delete → 409
- [ ] Mark status=blocked; confirm filtered out of active list

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_