### PR TITLE
feat: Global search controller across expenses, users, vendors, projects, and categories

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class SearchController extends Controller
+{
+    private const MAX_RESULTS_PER_TYPE = 5;
+    private const MIN_QUERY_LENGTH     = 2;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate([
+            'q'    => 'required|string|min:' . self::MIN_QUERY_LENGTH . '|max:100',
+            'type' => 'nullable|in:expense,user,vendor,project,category',
+        ]);
+
+        $q        = $request->input('q');
+        $type     = $request->input('type');
+        $tenantId = Auth::user()->tenant_id;
+        $results  = [];
+
+        if (!$type || $type === 'expense') {
+            $results['expenses'] = $this->searchExpenses($q, $tenantId);
+        }
+
+        if (!$type || $type === 'user') {
+            $results['users'] = $this->searchUsers($q, $tenantId);
+        }
+
+        if (!$type || $type === 'vendor') {
+            $results['vendors'] = $this->searchVendors($q, $tenantId);
+        }
+
+        if (!$type || $type === 'project') {
+            $results['projects'] = $this->searchProjects($q, $tenantId);
+        }
+
+        if (!$type || $type === 'category') {
+            $results['categories'] = $this->searchCategories($q, $tenantId);
+        }
+
+        $total = array_sum(array_map('count', $results));
+
+        return response()->json([
+            'query'   => $q,
+            'total'   => $total,
+            'results' => $results,
+        ]);
+    }
+
+    private function searchExpenses(string $q, int $tenantId): array
+    {
+        return DB::table('expenses')
+            ->where('tenant_id', $tenantId)
+            ->whereNull('deleted_at')
+            ->where(fn ($qb) => $qb
+                ->where('title', 'like', "%{$q}%")
+                ->orWhere('description', 'like', "%{$q}%")
+            )
+            ->select('id', 'title', 'amount', 'currency', 'status', 'expense_date')
+            ->orderByDesc('expense_date')
+            ->limit(self::MAX_RESULTS_PER_TYPE)
+            ->get()
+            ->map(fn ($row) => [
+                'type'     => 'expense',
+                'id'       => $row->id,
+                'label'    => $row->title,
+                'sub'      => "¥" . number_format($row->amount) . ' · ' . $row->status,
+                'url'      => "/expenses/{$row->id}",
+            ])
+            ->all();
+    }
+
+    private function searchUsers(string $q, int $tenantId): array
+    {
+        return DB::table('users')
+            ->where('tenant_id', $tenantId)
+            ->where('is_active', true)
+            ->where(fn ($qb) => $qb
+                ->where('name', 'like', "%{$q}%")
+                ->orWhere('email', 'like', "%{$q}%")
+            )
+            ->select('id', 'name', 'email', 'role')
+            ->orderBy('name')
+            ->limit(self::MAX_RESULTS_PER_TYPE)
+            ->get()
+            ->map(fn ($row) => [
+                'type'  => 'user',
+                'id'    => $row->id,
+                'label' => $row->name,
+                'sub'   => $row->email,
+                'url'   => "/admin/users/{$row->id}",
+            ])
+            ->all();
+    }
+
+    private function searchVendors(string $q, int $tenantId): array
+    {
+        return DB::table('vendors')
+            ->where('tenant_id', $tenantId)
+            ->whereNull('deleted_at')
+            ->where(fn ($qb) => $qb
+                ->where('name', 'like', "%{$q}%")
+                ->orWhere('code', 'like', "%{$q}%")
+                ->orWhere('email', 'like', "%{$q}%")
+            )
+            ->select('id', 'name', 'code', 'status')
+            ->orderBy('name')
+            ->limit(self::MAX_RESULTS_PER_TYPE)
+            ->get()
+            ->map(fn ($row) => [
+                'type'  => 'vendor',
+                'id'    => $row->id,
+                'label' => $row->name,
+                'sub'   => $row->code ?? $row->status,
+                'url'   => "/vendors/{$row->id}",
+            ])
+            ->all();
+    }
+
+    private function searchProjects(string $q, int $tenantId): array
+    {
+        return DB::table('projects')
+            ->where('tenant_id', $tenantId)
+            ->whereNull('deleted_at')
+            ->where(fn ($qb) => $qb
+                ->where('name', 'like', "%{$q}%")
+                ->orWhere('code', 'like', "%{$q}%")
+            )
+            ->select('id', 'name', 'code', 'status')
+            ->orderBy('name')
+            ->limit(self::MAX_RESULTS_PER_TYPE)
+            ->get()
+            ->map(fn ($row) => [
+                'type'  => 'project',
+                'id'    => $row->id,
+                'label' => $row->name,
+                'sub'   => "{$row->code} · {$row->status}",
+                'url'   => "/projects/{$row->id}",
+            ])
+            ->all();
+    }
+
+    private function searchCategories(string $q, int $tenantId): array
+    {
+        return DB::table('expense_categories')
+            ->where('tenant_id', $tenantId)
+            ->whereNull('deleted_at')
+            ->where('is_active', true)
+            ->where(fn ($qb) => $qb
+                ->where('name', 'like', "%{$q}%")
+                ->orWhere('code', 'like', "%{$q}%")
+            )
+            ->select('id', 'name', 'code', 'color')
+            ->orderBy('sort_order')
+            ->limit(self::MAX_RESULTS_PER_TYPE)
+            ->get()
+            ->map(fn ($row) => [
+                'type'  => 'category',
+                'id'    => $row->id,
+                'label' => $row->name,
+                'sub'   => $row->code,
+                'url'   => "/categories/{$row->id}",
+                'color' => $row->color,
+            ])
+            ->all();
+    }
+}

--- a/tests/Feature/SearchControllerTest.php
+++ b/tests/Feature/SearchControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SearchControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1, 'name' => 'Alice', 'email' => 'alice@test.com']);
+        $this->actingAs($this->user);
+    }
+
+    public function test_requires_minimum_query_length(): void
+    {
+        $this->getJson('/api/search?q=a')->assertUnprocessable();
+    }
+
+    public function test_returns_users_matching_name(): void
+    {
+        $response = $this->getJson('/api/search?q=Alice&type=user')->assertOk();
+        $this->assertNotEmpty($response->json('results.users'));
+        $this->assertSame('Alice', $response->json('results.users.0.label'));
+    }
+
+    public function test_cross_tenant_users_not_returned(): void
+    {
+        User::factory()->create(['tenant_id' => 99, 'name' => 'Alice Other', 'email' => 'other@other.com']);
+
+        $response = $this->getJson('/api/search?q=Alice&type=user')->assertOk();
+        // Only the current tenant's Alice should appear
+        $this->assertCount(1, $response->json('results.users'));
+    }
+
+    public function test_total_sums_across_types(): void
+    {
+        $response = $this->getJson('/api/search?q=test')->assertOk();
+        $results  = $response->json('results');
+        $sum      = array_sum(array_map('count', $results));
+        $this->assertSame($response->json('total'), $sum);
+    }
+
+    public function test_type_filter_limits_result_keys(): void
+    {
+        $response = $this->getJson('/api/search?q=Alice&type=user')->assertOk();
+        $keys     = array_keys($response->json('results'));
+        $this->assertSame(['users'], $keys);
+    }
+}


### PR DESCRIPTION
## Summary

- Add invokable `SearchController` for global cross-entity search
- Searches across: expenses (title/description), users (name/email), vendors (name/code/email), projects (name/code), categories (name/code)
- Optional `?type=` filter limits search to a single entity type
- Max 5 results per entity type; returns unified `{type, id, label, sub, url}` shape for CommandPalette
- `total` field sums result counts across all types

## Security

- All queries scoped by `tenant_id` — cross-tenant data never returned
- Minimum query length: 2 characters (validated)
- LIKE patterns use `%q%` with no raw interpolation

## Tests (5 feature tests)

- Rejects `q` shorter than 2 chars → 422
- User name search returns matching user
- Cross-tenant users excluded from results
- `total` equals sum of all result counts
- `?type=user` restricts result keys to `users` only

## Test plan

- [ ] Search "Alice" — user result appears
- [ ] Search with cross-tenant entity name — not returned
- [ ] `?type=vendor` — only `vendors` key in response
- [ ] Search single character → 422

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_