### PR TITLE
feat: Budget controller with period types, utilization stats, and alert threshold tracking

### DIFF
--- a/app/Http/Controllers/Api/BudgetController.php
+++ b/app/Http/Controllers/Api/BudgetController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Budget;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class BudgetController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'budget_type' => 'nullable|in:department,project,category,user',
+            'active_only' => 'boolean',
+            'period'      => 'nullable|in:current,upcoming,past',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+        $query    = Budget::where('tenant_id', $tenantId)->orderBy('name');
+
+        if ($request->filled('budget_type')) {
+            $query->where('budget_type', $request->input('budget_type'));
+        }
+
+        if ($request->boolean('active_only')) {
+            $query->where('is_active', true);
+        }
+
+        if ($request->filled('period')) {
+            $today = now()->toDateString();
+            match ($request->input('period')) {
+                'current'  => $query->where('period_start', '<=', $today)->where('period_end', '>=', $today),
+                'upcoming' => $query->where('period_start', '>', $today),
+                'past'     => $query->where('period_end', '<', $today),
+            };
+        }
+
+        $budgets = $query->paginate(20);
+        $ids     = collect($budgets->items())->pluck('id');
+
+        // Batch-load utilization
+        $utilization = $this->batchUtilization($ids->all(), $tenantId);
+
+        $items = collect($budgets->items())->map(function ($b) use ($utilization) {
+            $spent = $utilization[$b->id] ?? 0;
+            return array_merge($b->toArray(), [
+                'spent_amount'    => $spent,
+                'utilization_pct' => $b->amount > 0 ? round($spent / $b->amount * 100, 1) : 0,
+                'is_over_budget'  => $spent > $b->amount,
+                'is_near_alert'   => $b->amount > 0 && ($spent / $b->amount * 100) >= $b->alert_threshold,
+            ]);
+        });
+
+        return response()->json([
+            'data' => $items,
+            'meta' => ['current_page' => $budgets->currentPage(), 'last_page' => $budgets->lastPage(), 'total' => $budgets->total()],
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $validated = $request->validate([
+            'name'            => 'required|string|max:120',
+            'budget_type'     => 'required|in:department,project,category,user',
+            'target_id'       => 'nullable|integer|min:1',
+            'period_type'     => 'required|in:monthly,quarterly,annual,custom',
+            'period_start'    => 'required|date',
+            'period_end'      => 'required|date|after_or_equal:period_start',
+            'amount'          => 'required|integer|min:1',
+            'currency'        => 'required|string|size:3',
+            'alert_threshold' => 'integer|min:10|max:100',
+        ]);
+
+        $budget = Budget::create(array_merge($validated, ['tenant_id' => $tenantId]));
+
+        return response()->json(['data' => $budget], 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+        $budget   = Budget::where('tenant_id', $tenantId)->findOrFail($id);
+        $spent    = $this->batchUtilization([$id], $tenantId)[$id] ?? 0;
+
+        return response()->json(['data' => array_merge($budget->toArray(), [
+            'spent_amount'    => $spent,
+            'utilization_pct' => $budget->amount > 0 ? round($spent / $budget->amount * 100, 1) : 0,
+        ])]);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $budget = Budget::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'            => 'sometimes|string|max:120',
+            'period_start'    => 'sometimes|date',
+            'period_end'      => 'sometimes|date|after_or_equal:period_start',
+            'amount'          => 'sometimes|integer|min:1',
+            'alert_threshold' => 'sometimes|integer|min:10|max:100',
+            'is_active'       => 'sometimes|boolean',
+        ]);
+
+        $budget->update($validated);
+
+        return response()->json(['data' => $budget->fresh()]);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        Budget::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id)->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function batchUtilization(array $budgetIds, int $tenantId): array
+    {
+        if (empty($budgetIds)) return [];
+
+        // This join assumes expenses have budget_id; adjust if budget type mapping differs
+        $rows = DB::table('expenses')
+            ->whereIn('budget_id', $budgetIds)
+            ->where('tenant_id', $tenantId)
+            ->whereIn('status', ['approved', 'submitted'])
+            ->whereNull('deleted_at')
+            ->groupBy('budget_id')
+            ->select('budget_id', DB::raw('SUM(amount) as total'))
+            ->pluck('total', 'budget_id')
+            ->all();
+
+        return array_map('intval', $rows);
+    }
+}

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Budget extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'name', 'budget_type', 'target_id', 'period_type',
+        'period_start', 'period_end', 'amount', 'currency', 'alert_threshold', 'is_active',
+    ];
+
+    protected $casts = [
+        'amount'          => 'integer',
+        'alert_threshold' => 'integer',
+        'is_active'       => 'boolean',
+        'period_start'    => 'date',
+        'period_end'      => 'date',
+    ];
+}

--- a/database/migrations/2024_01_15_000040_create_budgets_table.php
+++ b/database/migrations/2024_01_15_000040_create_budgets_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('budgets', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name');
+            $table->enum('budget_type', ['department', 'project', 'category', 'user']);
+            $table->unsignedBigInteger('target_id')->nullable();
+            $table->enum('period_type', ['monthly', 'quarterly', 'annual', 'custom']);
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->unsignedBigInteger('amount');
+            $table->string('currency', 3)->default('JPY');
+            $table->unsignedTinyInteger('alert_threshold')->default(80);
+            $table->boolean('is_active')->default(true);
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'budget_type', 'is_active']);
+            $table->index(['tenant_id', 'period_start', 'period_end']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('budgets');
+    }
+};


### PR DESCRIPTION
## Summary

- Add `Budget` model + migration + `BudgetController`
- Four budget types: `department`, `project`, `category`, `user`; four period types: `monthly`, `quarterly`, `annual`, `custom`
- `index`: filter by `budget_type`, `active_only`, `period` (current/upcoming/past); batch-loads utilization via `SUM(amount)` grouped by `budget_id`
- Each response item includes: `spent_amount`, `utilization_pct`, `is_over_budget`, `is_near_alert`
- `alert_threshold` (10–100%, default 80) drives near-alert flag

## Migration

- `budgets` table with compound indexes on `(tenant_id, budget_type, is_active)` and `(tenant_id, period_start, period_end)`
- Soft deletes

## Test plan

- [ ] Create monthly department budget; submit expenses; check utilization_pct
- [ ] Filter `?period=current` returns only budgets spanning today
- [ ] `is_near_alert` becomes true when spent ≥ alert_threshold%
- [ ] `is_over_budget` becomes true when spent > amount
- [ ] Delete budget → soft delete (can be restored)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_