### PR TITLE
feat: Error pages (404/403/500) with dark mode and React ErrorBoundary

### DIFF
--- a/resources/js/components/ErrorBoundary.tsx
+++ b/resources/js/components/ErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import { Component, type ReactNode } from 'react';
+import ServerErrorPage from '../pages/errors/ServerErrorPage';
+
+interface Props  { children: ReactNode }
+interface State  { hasError: boolean; message?: string }
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, message: error.message };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    // Log to error tracking in production
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[ErrorBoundary]', error.message, info.componentStack);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ServerErrorPage message={this.state.message} />;
+    }
+    return this.props.children;
+  }
+}

--- a/resources/js/pages/errors/ForbiddenPage.tsx
+++ b/resources/js/pages/errors/ForbiddenPage.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function ForbiddenPage() {
+  const navigate = useNavigate();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-950">
+      <div className="text-center">
+        <p className="text-sm font-semibold uppercase tracking-widest text-red-600 dark:text-red-400">
+          403
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-5xl">
+          アクセス権限がありません
+        </h1>
+        <p className="mt-4 text-base text-gray-500 dark:text-gray-400">
+          このページへのアクセスは許可されていません。
+          必要な権限がある場合は管理者にお問い合わせください。
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            &larr; 戻る
+          </button>
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            ダッシュボードへ
+          </button>
+        </div>
+      </div>
+      <div className="mt-16 text-9xl font-black text-gray-100 dark:text-gray-800 select-none" aria-hidden="true">
+        403
+      </div>
+    </main>
+  );
+}

--- a/resources/js/pages/errors/NotFoundPage.tsx
+++ b/resources/js/pages/errors/NotFoundPage.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-950">
+      <div className="text-center">
+        <p className="text-sm font-semibold uppercase tracking-widest text-blue-600 dark:text-blue-400">
+          404
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-5xl">
+          ページが見つかりません
+        </h1>
+        <p className="mt-4 text-base text-gray-500 dark:text-gray-400">
+          お探しのページは存在しないか、移動または削除された可能性があります。
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            &larr; 前のページに戻る
+          </button>
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            ダッシュボードへ
+          </button>
+        </div>
+      </div>
+      <div className="mt-16 text-9xl font-black text-gray-100 dark:text-gray-800 select-none" aria-hidden="true">
+        404
+      </div>
+    </main>
+  );
+}

--- a/resources/js/pages/errors/ServerErrorPage.tsx
+++ b/resources/js/pages/errors/ServerErrorPage.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function ServerErrorPage({ message }: { message?: string }) {
+  const navigate = useNavigate();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-950">
+      <div className="text-center">
+        <p className="text-sm font-semibold uppercase tracking-widest text-orange-600 dark:text-orange-400">
+          500
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-5xl">
+          サーバーエラーが発生しました
+        </h1>
+        <p className="mt-4 text-base text-gray-500 dark:text-gray-400">
+          {message ??
+            '予期しないエラーが発生しました。しばらくしてから再度お試しください。'}
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            再読み込み
+          </button>
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            ダッシュボードへ
+          </button>
+        </div>
+      </div>
+      <div className="mt-16 text-9xl font-black text-gray-100 dark:text-gray-800 select-none" aria-hidden="true">
+        500
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Add three error page components: `NotFoundPage` (404), `ForbiddenPage` (403), `ServerErrorPage` (500)
- Add `ErrorBoundary` class component that catches unhandled React render errors and renders `ServerErrorPage`
- All pages support dark mode via Tailwind `dark:` variants
- Large decorative error code in background (`text-gray-100 dark:text-gray-800`, `aria-hidden="true"`)

## Pages

| Page | Code | CTA buttons |
|---|---|---|
| `NotFoundPage` | 404 | ← 前のページに戻る, ダッシュボードへ |
| `ForbiddenPage` | 403 | ← 戻る, ダッシュボードへ |
| `ServerErrorPage` | 500 | 再読み込み, ダッシュボードへ |

## ErrorBoundary

- `getDerivedStateFromError` captures error message
- `componentDidCatch` logs to console in production (swap with Sentry etc.)
- Passes `message` prop to `ServerErrorPage` for context-specific messaging
- Wrap `<App>` in `<ErrorBoundary>` in `main.tsx`

## Test plan

- [ ] Navigate to unknown route → 404 page
- [ ] Access forbidden resource → 403 page
- [ ] Throw error in child component → `ErrorBoundary` renders 500 page with message
- [ ] All pages render correctly in dark mode

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_