### PR TITLE
feat: ApprovalController with workflow advancement engine

### DIFF
--- a/app/Http/Controllers/Api/ApprovalController.php
+++ b/app/Http/Controllers/Api/ApprovalController.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\Expense;
+use App\Models\ExpenseApproval;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ApprovalController extends Controller
+{
+    public function pending(Request $request): JsonResponse
+    {
+        $user     = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $approvals = ExpenseApproval::where('tenant_id', $tenantId)
+            ->where('approver_id', $user->id)
+            ->whereNull('action')
+            ->with(['expense.submitter', 'expense.category'])
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn ($a) => [
+                'id'         => $a->id,
+                'step_name'  => $a->step_name,
+                'deadline_at' => $a->deadline_at,
+                'is_overdue' => $a->deadline_at && now()->gt($a->deadline_at),
+                'expense'    => [
+                    'id'           => $a->expense->id,
+                    'title'        => $a->expense->title,
+                    'amount'       => $a->expense->amount,
+                    'currency'     => $a->expense->currency,
+                    'category'     => $a->expense->category?->name,
+                    'submitted_at' => $a->expense->submitted_at,
+                ],
+                'submitter' => [
+                    'id'       => $a->expense->submitter->id,
+                    'name'     => $a->expense->submitter->name,
+                    'avatar_url' => $a->expense->submitter->avatar_url,
+                ],
+            ]);
+
+        return response()->json(['data' => $approvals]);
+    }
+
+    public function approve(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate(['comment' => 'nullable|string|max:1000']);
+
+        return $this->processAction($id, 'approved', $validated['comment'] ?? null);
+    }
+
+    public function reject(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate(['comment' => 'required|string|max:1000']);
+
+        return $this->processAction($id, 'rejected', $validated['comment']);
+    }
+
+    public function bulkApprove(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'ids'   => 'required|array|min:1|max:50',
+            'ids.*' => 'integer|min:1',
+        ]);
+
+        $user     = Auth::user();
+        $tenantId = $user->tenant_id;
+        $approved = 0;
+        $skipped  = 0;
+
+        DB::transaction(function () use ($validated, $user, $tenantId, &$approved, &$skipped) {
+            foreach ($validated['ids'] as $id) {
+                $approval = ExpenseApproval::where('tenant_id', $tenantId)
+                    ->where('approver_id', $user->id)
+                    ->whereNull('action')
+                    ->find($id);
+
+                if (!$approval) { $skipped++; continue; }
+
+                $approval->update([
+                    'action'   => 'approved',
+                    'acted_at' => now(),
+                    'comment'  => null,
+                ]);
+
+                $this->advanceWorkflow($approval);
+                $approved++;
+            }
+        });
+
+        return response()->json([
+            'approved' => $approved,
+            'skipped'  => $skipped,
+        ]);
+    }
+
+    public function history(Request $request): JsonResponse
+    {
+        $user     = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $history = ExpenseApproval::where('tenant_id', $tenantId)
+            ->where('approver_id', $user->id)
+            ->whereNotNull('action')
+            ->with(['expense.submitter'])
+            ->orderByDesc('acted_at')
+            ->paginate((int) $request->input('per_page', 20));
+
+        return response()->json([
+            'data' => collect($history->items())->map(fn ($a) => [
+                'id'      => $a->id,
+                'action'  => $a->action,
+                'comment' => $a->comment,
+                'acted_at' => $a->acted_at,
+                'expense' => [
+                    'id'       => $a->expense->id,
+                    'title'    => $a->expense->title,
+                    'amount'   => $a->expense->amount,
+                    'currency' => $a->expense->currency,
+                ],
+                'submitter' => ['name' => $a->expense->submitter->name],
+            ]),
+            'meta' => [
+                'current_page' => $history->currentPage(),
+                'last_page'    => $history->lastPage(),
+                'total'        => $history->total(),
+            ],
+        ]);
+    }
+
+    private function processAction(int $id, string $action, ?string $comment): JsonResponse
+    {
+        $user     = Auth::user();
+        $tenantId = $user->tenant_id;
+
+        $approval = ExpenseApproval::where('tenant_id', $tenantId)
+            ->where('approver_id', $user->id)
+            ->whereNull('action')
+            ->findOrFail($id);
+
+        DB::transaction(function () use ($approval, $action, $comment) {
+            $approval->update([
+                'action'   => $action,
+                'acted_at' => now(),
+                'comment'  => $comment,
+            ]);
+
+            $this->advanceWorkflow($approval);
+        });
+
+        AuditLog::record("expense.{$action}", 'Expense', $approval->expense_id, [
+            'approval_id' => $id,
+            'comment'     => $comment,
+        ]);
+
+        return response()->json(['data' => $approval->fresh()]);
+    }
+
+    private function advanceWorkflow(ExpenseApproval $approval): void
+    {
+        $expense = $approval->expense;
+
+        if ($approval->action === 'rejected') {
+            $expense->update(['status' => 'rejected']);
+            // Cancel all remaining approval steps
+            ExpenseApproval::where('expense_id', $expense->id)
+                ->whereNull('action')
+                ->update(['action' => 'cancelled', 'acted_at' => now()]);
+            return;
+        }
+
+        // Check if all steps for this workflow level are approved
+        $pendingInStep = ExpenseApproval::where('expense_id', $expense->id)
+            ->where('step_order', $approval->step_order)
+            ->whereNull('action')
+            ->exists();
+
+        if ($pendingInStep) return;
+
+        // Advance to next step or mark approved
+        $nextStep = ExpenseApproval::where('expense_id', $expense->id)
+            ->where('step_order', '>', $approval->step_order)
+            ->whereNull('action')
+            ->orderBy('step_order')
+            ->first();
+
+        if (!$nextStep) {
+            $expense->update(['status' => 'approved', 'approved_at' => now()]);
+        }
+    }
+}

--- a/tests/Feature/ApprovalControllerTest.php
+++ b/tests/Feature/ApprovalControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Expense;
+use App\Models\ExpenseApproval;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApprovalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $approver;
+    private User $submitter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->approver  = User::factory()->create(['tenant_id' => 1, 'role' => 'manager']);
+        $this->submitter = User::factory()->create(['tenant_id' => 1]);
+        $this->actingAs($this->approver);
+    }
+
+    public function test_pending_returns_only_approvers_items(): void
+    {
+        $expense  = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'approver_id' => $this->approver->id]);
+
+        $other = User::factory()->create(['tenant_id' => 1]);
+        ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'approver_id' => $other->id]);
+
+        $response = $this->getJson('/api/approvals/pending')->assertOk();
+        $this->assertCount(1, $response->json('data'));
+    }
+
+    public function test_approve_sets_action_and_advances_workflow(): void
+    {
+        $expense  = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        $approval = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'approver_id' => $this->approver->id, 'step_order' => 1]);
+
+        $this->postJson("/api/approvals/{$approval->id}/approve", ['comment' => 'Looks good'])
+            ->assertOk();
+
+        $this->assertSame('approved', $approval->fresh()->action);
+        $this->assertSame('approved', $expense->fresh()->status);
+    }
+
+    public function test_reject_requires_comment(): void
+    {
+        $expense  = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        $approval = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'approver_id' => $this->approver->id]);
+
+        $this->postJson("/api/approvals/{$approval->id}/reject", [])->assertUnprocessable();
+    }
+
+    public function test_reject_cancels_remaining_steps(): void
+    {
+        $expense   = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        $step1     = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'approver_id' => $this->approver->id, 'step_order' => 1]);
+        $step2     = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $expense->id, 'step_order' => 2]);
+
+        $this->postJson("/api/approvals/{$step1->id}/reject", ['comment' => '不備あり'])->assertOk();
+
+        $this->assertSame('rejected', $expense->fresh()->status);
+        $this->assertSame('cancelled', $step2->fresh()->action);
+    }
+
+    public function test_bulk_approve_processes_multiple(): void
+    {
+        $e1 = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        $e2 = Expense::factory()->create(['tenant_id' => 1, 'user_id' => $this->submitter->id, 'status' => 'submitted']);
+        $a1 = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $e1->id, 'approver_id' => $this->approver->id]);
+        $a2 = ExpenseApproval::factory()->create(['tenant_id' => 1, 'expense_id' => $e2->id, 'approver_id' => $this->approver->id]);
+
+        $this->postJson('/api/approvals/bulk-approve', ['ids' => [$a1->id, $a2->id]])
+            ->assertOk()
+            ->assertJsonPath('approved', 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ApprovalController` with `pending()`, `approve()`, `reject()`, `bulkApprove()`, `history()` endpoints
- Implement `advanceWorkflow()`: rejection cascades to cancel remaining steps and marks expense rejected; approval checks all steps at same level before advancing to next step or marking expense approved
- Add `ApprovalControllerTest` with 5 feature tests covering the full approval lifecycle

## Changes
- `app/Http/Controllers/Api/ApprovalController.php` — approval workflow engine with bulk approve (max 50), DB transaction safety
- `tests/Feature/ApprovalControllerTest.php` — pending list, approve advances workflow, reject requires comment, reject cancels remaining steps, bulk approve

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_