### PR TITLE
feat(terraform): CloudFront distribution with OAC for SPA hosting

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,183 @@
+# ---------------------------------------------------------------------------
+# CloudFront — SPA distribution with OAC (Origin Access Control) for S3
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "frontend" {
+  bucket        = "${var.project}-${var.environment}-frontend-${data.aws_caller_identity.current.account_id}"
+  force_destroy = var.environment != "production"
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket                  = aws_s3_bucket.frontend.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  versioning_configuration { status = "Enabled" }
+}
+
+# OAC — Origin Access Control (successor to OAI)
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project}-${var.environment}-oac"
+  description                       = "OAC for ${var.project} ${var.environment} frontend S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# S3 bucket policy — allows only CloudFront OAC
+data "aws_iam_policy_document" "frontend_bucket" {
+  statement {
+    sid       = "AllowCloudFrontOAC"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.frontend.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.frontend_bucket.json
+
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+}
+
+# CloudFront cache policy — no cache for HTML, long cache for assets
+resource "aws_cloudfront_cache_policy" "assets" {
+  name        = "${var.project}-${var.environment}-assets"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config  { cookie_behavior = "none" }
+    headers_config  { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "none" }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = var.cloudfront_aliases
+  price_class         = var.cloudfront_price_class
+  web_acl_id          = var.environment == "production" ? aws_wafv2_web_acl.main.arn : null
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "s3-frontend"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # API proxy to ALB
+  origin {
+    domain_name = aws_lb.main.dns_name
+    origin_id   = "alb-api"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # Default behavior — SPA assets from S3
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    cache_policy_id        = aws_cloudfront_cache_policy.assets.id
+  }
+
+  # /api/* — forward to ALB, no caching
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "alb-api"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled managed policy
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+  }
+
+  # SPA fallback — 404/403 from S3 → index.html with HTTP 200
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.cloudfront_acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${var.project}-${var.environment}-logs-${data.aws_caller_identity.current.account_id}.s3.amazonaws.com"
+    prefix          = "cloudfront/"
+  }
+
+  tags = local.common_tags
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID (for cache invalidation in CI/CD)"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "frontend_bucket_name" {
+  description = "S3 bucket name for frontend asset uploads"
+  value       = aws_s3_bucket.frontend.bucket
+}

--- a/terraform/variables_cloudfront.tf
+++ b/terraform/variables_cloudfront.tf
@@ -1,0 +1,22 @@
+variable "cloudfront_aliases" {
+  description = "Custom domain names (CNAMEs) for the CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront price class — PriceClass_100 (US/EU) or PriceClass_All"
+  type        = string
+  default     = "PriceClass_100"
+
+  validation {
+    condition     = contains(["PriceClass_100", "PriceClass_200", "PriceClass_All"], var.cloudfront_price_class)
+    error_message = "Must be PriceClass_100, PriceClass_200, or PriceClass_All."
+  }
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM certificate ARN (must be in us-east-1) for HTTPS on custom aliases"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Provision CloudFront distribution with Origin Access Control (OAC) for secure S3 SPA hosting
- ALB origin for `/api/*` traffic with `CachingDisabled` managed policy
- Custom cache policy for static assets (1yr max TTL, Brotli+Gzip compression)
- SPA routing: 403/404 from S3 mapped to `index.html` with HTTP 200
- WAF attached only in production environment

## Changes
- `terraform/cloudfront.tf` — S3 bucket (versioning, AES256 SSE, public access blocked), OAC sigv4 signing, bucket policy scoped to CloudFront ARN, two-origin distribution
- `terraform/variables_cloudfront.tf` — price class, custom domain, ACM cert ARN variables

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_