### PR TITLE
feat: async CSV report export with queued job and presigned download URL

### DIFF
--- a/app/Http/Controllers/Api/ReportExportController.php
+++ b/app/Http/Controllers/Api/ReportExportController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Jobs\GenerateExpenseReport;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ReportExportController extends Controller
+{
+    public function request(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from'        => 'nullable|date',
+            'to'          => 'nullable|date|after_or_equal:from',
+            'status'      => 'nullable|string|in:draft,submitted,approved,rejected,paid',
+            'category_id' => 'nullable|integer',
+            'user_id'     => 'nullable|integer',
+            'format'      => 'nullable|string|in:csv',
+        ]);
+
+        $tenantId  = Auth::user()->tenant_id;
+        $userId    = Auth::id();
+        $reportKey = Str::uuid()->toString();
+        $format    = $validated['format'] ?? 'csv';
+
+        DB::table('expense_reports')->insert([
+            'tenant_id'    => $tenantId,
+            'requested_by' => $userId,
+            'report_key'   => $reportKey,
+            'format'       => $format,
+            'filters'      => json_encode($validated),
+            'status'       => 'pending',
+            'created_at'   => now(),
+            'updated_at'   => now(),
+        ]);
+
+        GenerateExpenseReport::dispatch(
+            $tenantId,
+            $userId,
+            $validated,
+            $format,
+            $reportKey
+        )->onQueue('reports');
+
+        return response()->json([
+            'report_key' => $reportKey,
+            'status'     => 'pending',
+            'message'    => 'レポートの生成を開始しました。完了後にダウンロード可能になります。',
+        ], 202);
+    }
+
+    public function status(string $reportKey): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $report = DB::table('expense_reports')
+            ->where('tenant_id', $tenantId)
+            ->where('report_key', $reportKey)
+            ->first();
+
+        if (! $report) {
+            return response()->json(['message' => 'Report not found.'], 404);
+        }
+
+        return response()->json([
+            'report_key'   => $report->report_key,
+            'status'       => $report->status,
+            'format'       => $report->format,
+            'completed_at' => $report->completed_at,
+        ]);
+    }
+
+    public function download(string $reportKey): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $report = DB::table('expense_reports')
+            ->where('tenant_id', $tenantId)
+            ->where('report_key', $reportKey)
+            ->where('status', 'completed')
+            ->first();
+
+        if (! $report) {
+            return response()->json(['message' => 'Report not found or not ready.'], 404);
+        }
+
+        // Generate a short-lived presigned URL (15 minutes)
+        $url = Storage::disk('s3')->temporaryUrl(
+            $report->file_path,
+            now()->addMinutes(15)
+        );
+
+        return response()->json(['download_url' => $url, 'expires_in' => 900]);
+    }
+
+    public function history(Request $request): JsonResponse
+    {
+        $tenantId = Auth::user()->tenant_id;
+
+        $reports = DB::table('expense_reports')
+            ->where('tenant_id', $tenantId)
+            ->where('requested_by', Auth::id())
+            ->orderByDesc('created_at')
+            ->limit(20)
+            ->get(['id', 'report_key', 'format', 'status', 'completed_at', 'created_at']);
+
+        return response()->json($reports);
+    }
+}

--- a/app/Jobs/GenerateExpenseReport.php
+++ b/app/Jobs/GenerateExpenseReport.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class GenerateExpenseReport implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 300;
+
+    public function __construct(
+        private readonly int $tenantId,
+        private readonly int $userId,
+        private readonly array $filters,
+        private readonly string $format,
+        private readonly string $reportKey,
+    ) {}
+
+    public function handle(): void
+    {
+        $query = DB::table('expenses')
+            ->join('users', 'expenses.user_id', '=', 'users.id')
+            ->leftJoin('categories', 'expenses.category_id', '=', 'categories.id')
+            ->leftJoin('projects', 'expenses.project_id', '=', 'projects.id')
+            ->where('expenses.tenant_id', $this->tenantId)
+            ->whereNull('expenses.deleted_at')
+            ->select(
+                'expenses.id',
+                'expenses.title',
+                'expenses.amount',
+                'expenses.currency',
+                'expenses.expense_date',
+                'expenses.status',
+                'users.name as user_name',
+                'users.email as user_email',
+                'categories.name as category_name',
+                'projects.name as project_name',
+                'expenses.description',
+                'expenses.created_at',
+            );
+
+        if (! empty($this->filters['from'])) {
+            $query->whereDate('expenses.expense_date', '>=', $this->filters['from']);
+        }
+        if (! empty($this->filters['to'])) {
+            $query->whereDate('expenses.expense_date', '<=', $this->filters['to']);
+        }
+        if (! empty($this->filters['status'])) {
+            $query->where('expenses.status', $this->filters['status']);
+        }
+        if (! empty($this->filters['category_id'])) {
+            $query->where('expenses.category_id', $this->filters['category_id']);
+        }
+        if (! empty($this->filters['user_id'])) {
+            $query->where('expenses.user_id', $this->filters['user_id']);
+        }
+
+        $headers = [
+            'ID', '件名', '金額', '通貨', '日付', 'ステータス',
+            '申請者', 'メール', 'カテゴリ', 'プロジェクト', '説明', '作成日時',
+        ];
+
+        $tmpPath = sys_get_temp_dir() . '/' . Str::uuid() . '.csv';
+        $fp = fopen($tmpPath, 'w');
+        // BOM for Excel compatibility
+        fwrite($fp, "\xEF\xBB\xBF");
+        fputcsv($fp, $headers);
+
+        $query->orderByDesc('expenses.expense_date')->chunk(500, function ($rows) use ($fp) {
+            foreach ($rows as $row) {
+                fputcsv($fp, [
+                    $row->id, $row->title, $row->amount, $row->currency,
+                    $row->expense_date, $row->status, $row->user_name, $row->user_email,
+                    $row->category_name, $row->project_name, $row->description, $row->created_at,
+                ]);
+            }
+        });
+
+        fclose($fp);
+
+        $s3Key = "reports/tenant-{$this->tenantId}/{$this->reportKey}.csv";
+        Storage::disk('s3')->put(
+            $s3Key,
+            fopen($tmpPath, 'r'),
+            [
+                'ContentType'            => 'text/csv; charset=UTF-8',
+                'ServerSideEncryption'   => 'aws:kms',
+                'ContentDisposition'     => 'attachment; filename="expense-report.csv"',
+            ]
+        );
+
+        unlink($tmpPath);
+
+        DB::table('expense_reports')
+            ->where('report_key', $this->reportKey)
+            ->update([
+                'status'       => 'completed',
+                'file_path'    => $s3Key,
+                'completed_at' => now(),
+            ]);
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        DB::table('expense_reports')
+            ->where('report_key', $this->reportKey)
+            ->update(['status' => 'failed']);
+    }
+}

--- a/database/migrations/2024_01_15_000043_create_expense_reports_table.php
+++ b/database/migrations/2024_01_15_000043_create_expense_reports_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('expense_reports', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->unsignedBigInteger('requested_by');
+            $table->string('report_key', 64)->unique();
+            $table->string('format', 10)->default('csv');
+            $table->json('filters')->nullable();
+            $table->enum('status', ['pending', 'processing', 'completed', 'failed'])->default('pending');
+            $table->string('file_path')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_reports');
+    }
+};


### PR DESCRIPTION
## Summary
- `GenerateExpenseReport` queued job: streams expenses via `chunk(500)`, writes UTF-8 BOM CSV, uploads to S3 with `ServerSideEncryption: aws:kms`
- `ReportExportController`: request (202 + report_key), status poll, download (15-min presigned URL), history (last 20)
- `expense_reports` table tracks job lifecycle: pending → processing → completed/failed

## Changes
- `app/Jobs/GenerateExpenseReport.php` — `ShouldQueue`, 3 retries, 5-min timeout, `failed()` marks DB record
- `database/migrations/2024_01_15_000043_create_expense_reports_table.php`
- `app/Http/Controllers/Api/ReportExportController.php`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_