### PR TITLE
feat: Webhook integration with HMAC-SHA256 signing and delivery history

### DIFF
--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class WebhookController extends Controller
+{
+    private const ALLOWED_EVENTS = [
+        'expense.created', 'expense.submitted', 'expense.approved',
+        'expense.rejected', 'expense.paid', 'approval.requested',
+    ];
+
+    public function index(): JsonResponse
+    {
+        $webhooks = Webhook::where('tenant_id', Auth::user()->tenant_id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'url', 'events', 'is_active', 'last_triggered_at', 'last_status']);
+
+        return response()->json($webhooks);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'            => 'required|string|max:100',
+            'url'             => 'required|url|max:500',
+            'events'          => 'required|array|min:1',
+            'events.*'        => 'string|in:' . implode(',', self::ALLOWED_EVENTS),
+            'timeout_seconds' => 'nullable|integer|between:5,30',
+            'retry_count'     => 'nullable|integer|between:0,5',
+        ]);
+
+        $webhook = Webhook::create([
+            ...$validated,
+            'tenant_id'       => Auth::user()->tenant_id,
+            'secret'          => Str::random(40),
+            'timeout_seconds' => $validated['timeout_seconds'] ?? 10,
+            'retry_count'     => $validated['retry_count'] ?? 3,
+        ]);
+
+        // Return secret only at creation time
+        return response()->json([
+            'id'     => $webhook->id,
+            'secret' => $webhook->secret,
+        ] + $webhook->makeVisible('secret')->toArray(), 201);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $webhook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'            => 'sometimes|string|max:100',
+            'url'             => 'sometimes|url|max:500',
+            'events'          => 'sometimes|array|min:1',
+            'events.*'        => 'string|in:' . implode(',', self::ALLOWED_EVENTS),
+            'is_active'       => 'sometimes|boolean',
+            'timeout_seconds' => 'sometimes|integer|between:5,30',
+            'retry_count'     => 'sometimes|integer|between:0,5',
+        ]);
+
+        $webhook->update($validated);
+
+        return response()->json($webhook);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $webhook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+        $webhook->delete();
+
+        return response()->json(null, 204);
+    }
+
+    public function rotateSecret(int $id): JsonResponse
+    {
+        $webhook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+        $newSecret = Str::random(40);
+        $webhook->update(['secret' => $newSecret]);
+
+        return response()->json(['secret' => $newSecret]);
+    }
+
+    public function deliveries(int $id): JsonResponse
+    {
+        $webhook = Webhook::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $deliveries = $webhook->deliveries()
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get(['id', 'event', 'response_status', 'duration_ms', 'attempt', 'success', 'created_at']);
+
+        return response()->json($deliveries);
+    }
+
+    /**
+     * Dispatch a webhook delivery with HMAC-SHA256 signature and retry.
+     * Called internally by jobs/observers — not a route.
+     */
+    public static function dispatch(Webhook $webhook, string $event, array $payload): void
+    {
+        if (! $webhook->is_active) {
+            return;
+        }
+
+        $body      = json_encode($payload);
+        $signature = hash_hmac('sha256', $body, $webhook->secret);
+        $attempt   = 1;
+        $success   = false;
+        $responseStatus = null;
+        $responseBody   = null;
+        $durationMs     = null;
+
+        while ($attempt <= $webhook->retry_count + 1) {
+            $start = microtime(true);
+
+            try {
+                $response = Http::timeout($webhook->timeout_seconds)
+                    ->withHeaders([
+                        'Content-Type'           => 'application/json',
+                        'X-Signature-SHA256'     => 'sha256=' . $signature,
+                        'X-Webhook-Event'        => $event,
+                        'X-Webhook-Delivery'     => Str::uuid(),
+                    ])
+                    ->post($webhook->url, $payload);
+
+                $responseStatus = $response->status();
+                $responseBody   = substr($response->body(), 0, 1000);
+                $durationMs     = (int) ((microtime(true) - $start) * 1000);
+                $success        = $response->successful();
+
+                if ($success) break;
+            } catch (\Throwable) {
+                $durationMs = (int) ((microtime(true) - $start) * 1000);
+            }
+
+            $attempt++;
+            if ($attempt <= $webhook->retry_count + 1) {
+                sleep(2 ** ($attempt - 2)); // exponential backoff: 1s, 2s, 4s
+            }
+        }
+
+        \Illuminate\Support\Facades\DB::table('webhook_deliveries')->insert([
+            'webhook_id'      => $webhook->id,
+            'event'           => $event,
+            'payload'         => json_encode($payload),
+            'response_status' => $responseStatus,
+            'response_body'   => $responseBody,
+            'duration_ms'     => $durationMs,
+            'attempt'         => $attempt,
+            'success'         => $success,
+            'created_at'      => now(),
+            'updated_at'      => now(),
+        ]);
+
+        $webhook->update([
+            'last_triggered_at' => now(),
+            'last_status'       => $success ? 'success' : 'failure',
+        ]);
+    }
+}

--- a/app/Models/Webhook.php
+++ b/app/Models/Webhook.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Webhook extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'tenant_id', 'name', 'url', 'secret', 'events',
+        'is_active', 'timeout_seconds', 'retry_count',
+        'last_triggered_at', 'last_status',
+    ];
+
+    protected $casts = [
+        'events'             => 'array',
+        'is_active'          => 'boolean',
+        'last_triggered_at'  => 'datetime',
+    ];
+
+    protected $hidden = ['secret'];
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    public function sign(array $payload): string
+    {
+        return hash_hmac('sha256', json_encode($payload), $this->secret);
+    }
+}

--- a/database/migrations/2024_01_15_000044_create_webhooks_table.php
+++ b/database/migrations/2024_01_15_000044_create_webhooks_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name');
+            $table->string('url');
+            $table->string('secret', 64);
+            $table->json('events'); // ['expense.approved', 'expense.rejected', ...]
+            $table->boolean('is_active')->default(true);
+            $table->unsignedInteger('timeout_seconds')->default(10);
+            $table->unsignedInteger('retry_count')->default(3);
+            $table->timestamp('last_triggered_at')->nullable();
+            $table->enum('last_status', ['success', 'failure'])->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['tenant_id', 'is_active']);
+        });
+
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('webhook_id')->index();
+            $table->string('event');
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_status')->nullable();
+            $table->text('response_body')->nullable();
+            $table->unsignedInteger('duration_ms')->nullable();
+            $table->unsignedTinyInteger('attempt')->default(1);
+            $table->boolean('success')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+        Schema::dropIfExists('webhooks');
+    }
+};


### PR DESCRIPTION
## Summary
- Outbound webhook system: tenants register URLs + event filters; HMAC-SHA256 `X-Signature-SHA256` header on every delivery
- Exponential backoff retry (1s → 2s → 4s) up to configurable `retry_count`; delivery results stored in `webhook_deliveries`
- `rotateSecret` endpoint returns new secret only once; original stored value never exposed in list/show responses
- Full CRUD + delivery history (last 50) endpoints

## Changes
- `database/migrations/2024_01_15_000044_create_webhooks_table.php` — `webhooks` + `webhook_deliveries` tables
- `app/Models/Webhook.php` — `secret` in `$hidden`, `sign()` helper
- `app/Http/Controllers/Api/WebhookController.php` — CRUD, `rotateSecret`, `deliveries`, static `dispatch()` with retry

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_