### PR TITLE
feat: Tag system with pivot table and sync endpoint for expenses

### DIFF
--- a/app/Http/Controllers/Api/TagController.php
+++ b/app/Http/Controllers/Api/TagController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Expense;
+use App\Models\Tag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class TagController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $tags = Tag::where('tenant_id', Auth::user()->tenant_id)
+            ->withCount('expenses')
+            ->orderBy('name')
+            ->get();
+
+        return response()->json($tags);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'  => 'required|string|max:50',
+            'color' => 'nullable|string|regex:/^#[0-9A-Fa-f]{6}$/',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        $tag = Tag::firstOrCreate(
+            ['tenant_id' => $tenantId, 'name' => $validated['name']],
+            ['color'     => $validated['color'] ?? '#6B7280']
+        );
+
+        return response()->json($tag, 201);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $tag = Tag::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name'  => 'sometimes|string|max:50',
+            'color' => 'sometimes|string|regex:/^#[0-9A-Fa-f]{6}$/',
+        ]);
+
+        $tag->update($validated);
+
+        return response()->json($tag);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $tag = Tag::where('tenant_id', Auth::user()->tenant_id)->findOrFail($id);
+        $tag->expenses()->detach();
+        $tag->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /** Sync tags on an expense (replaces all existing tags). */
+    public function sync(Request $request, int $expenseId): JsonResponse
+    {
+        $validated = $request->validate([
+            'tag_ids'   => 'present|array',
+            'tag_ids.*' => 'integer',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        $expense = Expense::where('tenant_id', $tenantId)->findOrFail($expenseId);
+
+        // Only allow tags that belong to the same tenant
+        $allowedIds = Tag::where('tenant_id', $tenantId)
+            ->whereIn('id', $validated['tag_ids'])
+            ->pluck('id');
+
+        $expense->tags()->sync($allowedIds);
+
+        return response()->json($expense->load('tags:id,name,color'));
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Tag extends Model
+{
+    protected $fillable = ['tenant_id', 'name', 'color'];
+
+    public function expenses(): BelongsToMany
+    {
+        return $this->belongsToMany(Expense::class, 'expense_tag');
+    }
+}

--- a/database/migrations/2024_01_15_000048_create_tags_tables.php
+++ b/database/migrations/2024_01_15_000048_create_tags_tables.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id')->index();
+            $table->string('name', 50);
+            $table->string('color', 7)->default('#6B7280'); // hex color
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'name']);
+        });
+
+        Schema::create('expense_tag', function (Blueprint $table) {
+            $table->unsignedBigInteger('expense_id');
+            $table->unsignedBigInteger('tag_id');
+
+            $table->primary(['expense_id', 'tag_id']);
+            $table->index('tag_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_tag');
+        Schema::dropIfExists('tags');
+    }
+};


### PR DESCRIPTION
## Summary
- `tags` table with unique name per tenant and hex color; `expense_tag` pivot for M:N relationship
- `TagController`: CRUD with `firstOrCreate` for idempotent creation, `expenses_count` via `withCount`
- `sync()`: replaces all tags on an expense; cross-tenant tag IDs silently filtered before `sync()`
- `destroy()` detaches from all expenses before deleting to keep referential integrity

## Changes
- `database/migrations/2024_01_15_000048_create_tags_tables.php`
- `app/Models/Tag.php`
- `app/Http/Controllers/Api/TagController.php`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_