### PR TITLE
feat: CurrencyController with 1-hour cached exchange rates and JPY conversion

### DIFF
--- a/app/Http/Controllers/Api/CurrencyController.php
+++ b/app/Http/Controllers/Api/CurrencyController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class CurrencyController extends Controller
+{
+    private const CACHE_TTL   = 3600; // 1 hour
+    private const BASE        = 'JPY';
+    private const SUPPORTED   = ['USD', 'EUR', 'GBP', 'CNY', 'KRW', 'HKD', 'SGD', 'AUD', 'CAD', 'CHF'];
+
+    public function rates(): JsonResponse
+    {
+        $rates = Cache::remember('exchange_rates', self::CACHE_TTL, function () {
+            return $this->fetchRates();
+        });
+
+        return response()->json([
+            'base'       => self::BASE,
+            'rates'      => $rates,
+            'updated_at' => Cache::get('exchange_rates_updated_at'),
+        ]);
+    }
+
+    public function convert(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'amount' => 'required|numeric|min:0',
+            'from'   => 'required|string|size:3',
+            'to'     => 'nullable|string|size:3',
+        ]);
+
+        $from = strtoupper($validated['from']);
+        $to   = strtoupper($validated['to'] ?? self::BASE);
+
+        if ($from === $to) {
+            return response()->json([
+                'amount'         => $validated['amount'],
+                'converted'      => $validated['amount'],
+                'from'           => $from,
+                'to'             => $to,
+                'rate'           => 1.0,
+            ]);
+        }
+
+        $rates = Cache::remember('exchange_rates', self::CACHE_TTL, function () {
+            return $this->fetchRates();
+        });
+
+        // rates are all relative to JPY
+        // amount in `from` → JPY → `to`
+        $fromRate = $from === self::BASE ? 1.0 : ($rates[$from] ?? null);
+        $toRate   = $to   === self::BASE ? 1.0 : ($rates[$to]   ?? null);
+
+        if ($fromRate === null || $toRate === null) {
+            return response()->json(['message' => 'Unsupported currency.'], 422);
+        }
+
+        $inJpy    = $validated['amount'] / $fromRate;  // to JPY
+        $converted = $inJpy * $toRate;                  // to target currency
+
+        return response()->json([
+            'amount'    => $validated['amount'],
+            'converted' => round($converted, 2),
+            'from'      => $from,
+            'to'        => $to,
+            'rate'      => $toRate / $fromRate,
+        ]);
+    }
+
+    public function supported(): JsonResponse
+    {
+        return response()->json(['currencies' => array_merge([self::BASE], self::SUPPORTED)]);
+    }
+
+    private function fetchRates(): array
+    {
+        // Attempt to use a free exchange-rate API; fall back to hardcoded defaults
+        try {
+            $response = Http::timeout(5)
+                ->get('https://api.exchangerate-api.com/v4/latest/JPY');
+
+            if ($response->successful()) {
+                $data  = $response->json();
+                $rates = [];
+
+                foreach (self::SUPPORTED as $code) {
+                    if (isset($data['rates'][$code])) {
+                        $rates[$code] = $data['rates'][$code];
+                    }
+                }
+
+                Cache::put('exchange_rates_updated_at', now()->toIso8601String(), self::CACHE_TTL);
+
+                return $rates;
+            }
+        } catch (\Throwable) {
+            // fall through to defaults
+        }
+
+        // Hardcoded fallback rates (JPY-based, approximate)
+        return [
+            'USD' => 0.0067, 'EUR' => 0.0062, 'GBP' => 0.0053,
+            'CNY' => 0.048,  'KRW' => 8.9,    'HKD' => 0.052,
+            'SGD' => 0.0090, 'AUD' => 0.010,  'CAD' => 0.0091,
+            'CHF' => 0.0060,
+        ];
+    }
+}

--- a/tests/Feature/CurrencyControllerTest.php
+++ b/tests/Feature/CurrencyControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class CurrencyControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['tenant_id' => 1]);
+    }
+
+    public function test_rates_returns_jpy_base(): void
+    {
+        Cache::put('exchange_rates', ['USD' => 0.0067, 'EUR' => 0.0062], 3600);
+
+        $this->actingAs($this->user)
+            ->getJson('/api/currency/rates')
+            ->assertOk()
+            ->assertJsonPath('base', 'JPY')
+            ->assertJsonStructure(['base', 'rates']);
+    }
+
+    public function test_convert_same_currency_returns_same_amount(): void
+    {
+        $this->actingAs($this->user)
+            ->getJson('/api/currency/convert?amount=1000&from=JPY&to=JPY')
+            ->assertOk()
+            ->assertJsonPath('rate', 1.0)
+            ->assertJsonPath('converted', 1000);
+    }
+
+    public function test_convert_usd_to_jpy(): void
+    {
+        Cache::put('exchange_rates', ['USD' => 0.0067], 3600);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/currency/convert?amount=100&from=USD&to=JPY')
+            ->assertOk();
+
+        // 100 USD * (1 / 0.0067) = ~14925 JPY
+        $this->assertGreaterThan(10000, $response->json('converted'));
+    }
+
+    public function test_unsupported_currency_returns_422(): void
+    {
+        Cache::put('exchange_rates', ['USD' => 0.0067], 3600);
+
+        $this->actingAs($this->user)
+            ->getJson('/api/currency/convert?amount=100&from=XYZ&to=JPY')
+            ->assertUnprocessable();
+    }
+}


### PR DESCRIPTION
## Summary
- `rates()`: fetches exchange rates from external API, caches 1 hour; falls back to hardcoded approximate rates on failure
- `convert()`: JPY-pivot conversion (from → JPY → to) supporting 10 currencies
- `supported()`: lists all supported currency codes
- 4 feature tests: JPY base, same-currency identity, USD→JPY conversion, unsupported 422

## Changes
- `app/Http/Controllers/Api/CurrencyController.php`
- `tests/Feature/CurrencyControllerTest.php`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_