### PR TITLE
feat(terraform): ALB with HTTPS listener, HTTP→HTTPS redirect, and S3 access logs

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,136 @@
+# Application Load Balancer for the expense management API
+
+resource "aws_lb" "main" {
+  name               = "${var.project}-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = var.environment == "production"
+  enable_http2               = true
+  drop_invalid_header_fields = true
+
+  access_logs {
+    bucket  = aws_s3_bucket.alb_logs.id
+    prefix  = "alb"
+    enabled = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket" "alb_logs" {
+  bucket        = "${var.project}-${var.environment}-alb-logs"
+  force_destroy = var.environment != "production"
+  tags          = local.common_tags
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    id     = "expire-logs"
+    status = "Enabled"
+    expiration {
+      days = 90
+    }
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.project}-${var.environment}-app"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+    matcher             = "200"
+  }
+
+  deregistration_delay = 30
+
+  tags = local.common_tags
+}
+
+# HTTPS listener (primary)
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+
+  tags = local.common_tags
+}
+
+# HTTP → HTTPS redirect
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# ALB security group
+resource "aws_security_group" "alb" {
+  name        = "${var.project}-${var.environment}-alb"
+  description = "ALB security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTP for redirect"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTPS"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.common_tags
+}
+
+output "alb_dns_name" {
+  value = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  value = aws_lb.main.zone_id
+}
+
+output "alb_arn" {
+  value = aws_lb.main.arn
+}

--- a/terraform/variables_alb.tf
+++ b/terraform/variables_alb.tf
@@ -1,0 +1,19 @@
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for HTTPS listener"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for ALB placement"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for ECS task placement"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- ALB with `drop_invalid_header_fields = true` and HTTP/2 enabled
- HTTPS listener with `ELBSecurityPolicy-TLS13-1-2-2021-06` policy; HTTP 301 redirect
- Target group with `/health` check, 2-healthy/3-unhealthy thresholds, 30s deregistration delay
- S3 access log bucket with 90-day lifecycle expiry; deletion protection in production

## Changes
- `terraform/alb.tf` — ALB, S3 logs bucket, target group, HTTPS + HTTP listeners, security group
- `terraform/variables_alb.tf` — `acm_certificate_arn`, `public_subnet_ids`, `private_subnet_ids`, `vpc_id`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_