### PR TITLE
feat: GenerateMonthlyReports Artisan command with Queue::fake test

### DIFF
--- a/app/Console/Commands/GenerateMonthlyReports.php
+++ b/app/Console/Commands/GenerateMonthlyReports.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\GenerateExpenseReport;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class GenerateMonthlyReports extends Command
+{
+    protected $signature = 'reports:generate-monthly
+                            {--month= : Target month in YYYY-MM format (defaults to previous month)}
+                            {--tenant= : Generate only for this tenant ID}';
+
+    protected $description = 'Dispatch monthly expense report generation jobs for all active tenants';
+
+    public function handle(): int
+    {
+        $month = $this->option('month')
+            ? Carbon::createFromFormat('Y-m', $this->option('month'))->startOfMonth()
+            : now()->subMonth()->startOfMonth();
+
+        $from = $month->toDateString();
+        $to   = $month->copy()->endOfMonth()->toDateString();
+
+        $this->info("Generating monthly reports for {$from} → {$to}");
+
+        $query = DB::table('tenants')
+            ->where('is_active', true)
+            ->select('id');
+
+        if ($tenantId = $this->option('tenant')) {
+            $query->where('id', $tenantId);
+        }
+
+        $tenants = $query->get();
+
+        if ($tenants->isEmpty()) {
+            $this->warn('No active tenants found.');
+            return self::SUCCESS;
+        }
+
+        $dispatched = 0;
+
+        foreach ($tenants as $tenant) {
+            // Find the finance admin or first admin for this tenant
+            $user = DB::table('users')
+                ->where('tenant_id', $tenant->id)
+                ->where('is_active', true)
+                ->whereIn('role', ['finance', 'admin'])
+                ->orderByRaw("FIELD(role, 'finance', 'admin')")
+                ->value('id');
+
+            if (! $user) {
+                $this->warn("Tenant {$tenant->id}: no finance/admin user found, skipping.");
+                continue;
+            }
+
+            $reportKey = Str::uuid()->toString();
+            $filters   = ['from' => $from, 'to' => $to];
+
+            DB::table('expense_reports')->insert([
+                'tenant_id'    => $tenant->id,
+                'requested_by' => $user,
+                'report_key'   => $reportKey,
+                'format'       => 'csv',
+                'filters'      => json_encode($filters),
+                'status'       => 'pending',
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ]);
+
+            GenerateExpenseReport::dispatch(
+                $tenant->id,
+                $user,
+                $filters,
+                'csv',
+                $reportKey
+            )->onQueue('reports');
+
+            $dispatched++;
+            $this->line("  ✓ Tenant {$tenant->id} → {$reportKey}");
+        }
+
+        $this->info("Dispatched {$dispatched} report job(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/GenerateMonthlyReportsTest.php
+++ b/tests/Feature/GenerateMonthlyReportsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\GenerateExpenseReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class GenerateMonthlyReportsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_dispatches_jobs_for_active_tenants(): void
+    {
+        Queue::fake();
+
+        // Create tenants and finance users in the DB
+        \Illuminate\Support\Facades\DB::table('tenants')->insert([
+            ['id' => 1, 'name' => 'Tenant A', 'is_active' => true],
+            ['id' => 2, 'name' => 'Tenant B', 'is_active' => false], // inactive — should be skipped
+        ]);
+
+        \App\Models\User::factory()->create(['tenant_id' => 1, 'role' => 'finance', 'is_active' => true]);
+
+        $this->artisan('reports:generate-monthly', ['--month' => '2024-01'])
+            ->assertSuccessful();
+
+        Queue::assertPushed(GenerateExpenseReport::class, 1);
+    }
+
+    public function test_command_skips_tenants_without_finance_user(): void
+    {
+        Queue::fake();
+
+        \Illuminate\Support\Facades\DB::table('tenants')->insert([
+            ['id' => 3, 'name' => 'Tenant C', 'is_active' => true],
+        ]);
+
+        // No finance/admin user for tenant 3
+
+        $this->artisan('reports:generate-monthly', ['--month' => '2024-01', '--tenant' => 3])
+            ->assertSuccessful();
+
+        Queue::assertNothingPushed();
+    }
+}


### PR DESCRIPTION
## Summary
- Artisan command dispatches `GenerateExpenseReport` jobs for all active tenants; `--month` and `--tenant` options
- Selects finance user first, falls back to admin; skips tenants with no matching user
- Inserts `expense_reports` record before dispatching so status is trackable immediately
- 2 feature tests: dispatches correct job count, skips tenants without finance user

## Changes
- `app/Console/Commands/GenerateMonthlyReports.php` — `reports:generate-monthly` command
- `tests/Feature/GenerateMonthlyReportsTest.php` — `Queue::fake()` assertions

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_