### PR TITLE
feat(terraform): VPC with multi-AZ subnets, NAT gateway, and VPC Flow Logs

### DIFF
--- a/terraform/variables_vpc.tf
+++ b/terraform/variables_vpc.tf
@@ -1,0 +1,23 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of AZs to deploy subnets into"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create NAT Gateways for private subnets"
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway for all private subnets (cost saving for non-prod)"
+  type        = bool
+  default     = false
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,150 @@
+# VPC and networking for the expense management system
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}" })
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = merge(local.common_tags, { Name = "${var.project}-${var.environment}-igw" })
+}
+
+# Public subnets (one per AZ)
+resource "aws_subnet" "public" {
+  count                   = length(var.availability_zones)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project}-${var.environment}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  })
+}
+
+# Private subnets (one per AZ)
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones))
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project}-${var.environment}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  })
+}
+
+# Elastic IPs for NAT Gateways
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 0
+  domain = "vpc"
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}-nat-${count.index}" })
+}
+
+# NAT Gateways (one per AZ unless single_nat_gateway)
+resource "aws_nat_gateway" "main" {
+  count         = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 0
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}-nat-${count.index}" })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Public route table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}-public-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Private route tables (one per NAT gateway)
+resource "aws_route_table" "private" {
+  count  = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 1
+  vpc_id = aws_vpc.main.id
+
+  dynamic "route" {
+    for_each = var.enable_nat_gateway ? [1] : []
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.main[var.single_nat_gateway ? 0 : count.index].id
+    }
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.project}-${var.environment}-private-rt-${count.index}" })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}
+
+# VPC Flow Logs
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = "/aws/vpc/${var.project}-${var.environment}"
+  retention_in_days = 30
+  tags              = local.common_tags
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "${var.project}-${var.environment}-vpc-flow-logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "cloudwatch-logs"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogGroups", "logs:DescribeLogStreams"]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "main" {
+  vpc_id          = aws_vpc.main.id
+  traffic_type    = "ALL"
+  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
+
+  tags = local.common_tags
+}
+
+output "vpc_id"              { value = aws_vpc.main.id }
+output "public_subnet_ids"   { value = aws_subnet.public[*].id }
+output "private_subnet_ids"  { value = aws_subnet.private[*].id }


### PR DESCRIPTION
## Summary
- VPC with configurable CIDR; public + private subnets across 3 AZs (ap-northeast-1a/c/d)
- NAT Gateways: one per AZ (HA) or single (`single_nat_gateway = true` for cost saving in non-prod)
- `enable_nat_gateway = false` skips NAT entirely (dev/test with no internet egress needed)
- VPC Flow Logs to CloudWatch with 30-day retention and dedicated IAM role

## Changes
- `terraform/vpc.tf` — VPC, IGW, public/private subnets, EIPs, NAT GWs, route tables + associations, flow logs
- `terraform/variables_vpc.tf` — `vpc_cidr`, `availability_zones`, `enable_nat_gateway`, `single_nat_gateway`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_