### PR TITLE
feat: ProcessRecurringExpenses Artisan command with migration and tests

### DIFF
--- a/app/Console/Commands/ProcessRecurringExpenses.php
+++ b/app/Console/Commands/ProcessRecurringExpenses.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class ProcessRecurringExpenses extends Command
+{
+    protected $signature   = 'expenses:process-recurring {--date= : Date to process (YYYY-MM-DD, defaults to today)}';
+    protected $description = 'Create new expense instances from recurring expense templates';
+
+    public function handle(): int
+    {
+        $date = $this->option('date')
+            ? Carbon::parse($this->option('date'))
+            : today();
+
+        $this->info("Processing recurring expenses due on or before {$date->toDateString()}");
+
+        $templates = DB::table('expenses')
+            ->whereNull('deleted_at')
+            ->where('is_recurring', true)
+            ->whereNull('recurring_parent_id') // only root templates
+            ->where('next_recurrence_date', '<=', $date->toDateString())
+            ->get();
+
+        if ($templates->isEmpty()) {
+            $this->info('No recurring expenses due.');
+            return self::SUCCESS;
+        }
+
+        $created = 0;
+
+        foreach ($templates as $template) {
+            $now = now();
+
+            // Create new expense instance
+            $newId = DB::table('expenses')->insertGetId([
+                'tenant_id'            => $template->tenant_id,
+                'user_id'              => $template->user_id,
+                'category_id'          => $template->category_id,
+                'project_id'           => $template->project_id,
+                'title'                => $template->title,
+                'amount'               => $template->amount,
+                'currency'             => $template->currency,
+                'expense_date'         => $date->toDateString(),
+                'description'          => $template->description,
+                'status'               => 'draft',
+                'is_recurring'         => false,
+                'recurring_parent_id'  => $template->id,
+                'created_at'           => $now,
+                'updated_at'           => $now,
+            ]);
+
+            // Advance next_recurrence_date by 1 month
+            DB::table('expenses')
+                ->where('id', $template->id)
+                ->update([
+                    'next_recurrence_date' => Carbon::parse($template->next_recurrence_date)
+                        ->addMonth()
+                        ->toDateString(),
+                    'updated_at' => $now,
+                ]);
+
+            $created++;
+            $this->line("  ✓ Created expense #{$newId} from template #{$template->id} ({$template->title})");
+        }
+
+        $this->info("Created {$created} expense(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/database/migrations/2024_01_15_000049_add_recurring_columns_to_expenses_table.php
+++ b/database/migrations/2024_01_15_000049_add_recurring_columns_to_expenses_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->boolean('is_recurring')->default(false)->after('description');
+            $table->unsignedBigInteger('recurring_parent_id')->nullable()->after('is_recurring');
+            $table->date('next_recurrence_date')->nullable()->after('recurring_parent_id');
+
+            $table->index(['is_recurring', 'next_recurrence_date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropColumn(['is_recurring', 'recurring_parent_id', 'next_recurrence_date']);
+        });
+    }
+};

--- a/tests/Feature/ProcessRecurringExpensesTest.php
+++ b/tests/Feature/ProcessRecurringExpensesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ProcessRecurringExpensesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_new_expense_from_recurring_template(): void
+    {
+        $user = User::factory()->create(['tenant_id' => 1]);
+
+        $templateId = DB::table('expenses')->insertGetId([
+            'tenant_id'           => 1,
+            'user_id'             => $user->id,
+            'title'               => '交通費（毎月）',
+            'amount'              => 5000,
+            'currency'            => 'JPY',
+            'expense_date'        => '2024-01-01',
+            'status'              => 'draft',
+            'is_recurring'        => true,
+            'next_recurrence_date' => '2024-02-01',
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ]);
+
+        $this->artisan('expenses:process-recurring', ['--date' => '2024-02-01'])
+            ->assertSuccessful();
+
+        // New expense created
+        $this->assertDatabaseHas('expenses', [
+            'recurring_parent_id' => $templateId,
+            'expense_date'        => '2024-02-01',
+            'is_recurring'        => false,
+        ]);
+
+        // Template next date advanced
+        $this->assertDatabaseHas('expenses', [
+            'id'                   => $templateId,
+            'next_recurrence_date' => '2024-03-01',
+        ]);
+    }
+
+    public function test_skips_templates_not_yet_due(): void
+    {
+        $user = User::factory()->create(['tenant_id' => 1]);
+
+        DB::table('expenses')->insert([
+            'tenant_id'            => 1,
+            'user_id'              => $user->id,
+            'title'                => '家賃',
+            'amount'               => 100000,
+            'currency'             => 'JPY',
+            'expense_date'         => '2024-01-01',
+            'status'               => 'draft',
+            'is_recurring'         => true,
+            'next_recurrence_date' => '2024-03-01',
+            'created_at'           => now(),
+            'updated_at'           => now(),
+        ]);
+
+        $this->artisan('expenses:process-recurring', ['--date' => '2024-02-01'])
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('expenses', ['recurring_parent_id' => DB::table('expenses')->value('id')]);
+    }
+}


### PR DESCRIPTION
## Summary
- Migration adds `is_recurring`, `recurring_parent_id`, `next_recurrence_date` columns to `expenses`
- `expenses:process-recurring` command: instantiates draft expenses from recurring templates due on/before `--date`
- Advances `next_recurrence_date` by 1 month after each instantiation; supports `--date` override for backfill
- 2 feature tests: creates instance and advances date, skips templates not yet due

## Changes
- `database/migrations/2024_01_15_000049_add_recurring_columns_to_expenses_table.php`
- `app/Console/Commands/ProcessRecurringExpenses.php`
- `tests/Feature/ProcessRecurringExpensesTest.php`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH7CZBsEL22rcHfDiDW75v)_